### PR TITLE
Adjust fuel consumption for tank modules

### DIFF
--- a/common/units/equipment/modules/MD_tank_modules.txt
+++ b/common/units/equipment/modules/MD_tank_modules.txt
@@ -18,7 +18,7 @@ equipment_modules = {
 
 		add_stats = {
 			build_cost_ic = 1.55
-			fuel_consumption = 3.3
+			fuel_consumption = 2.8
 			maximum_speed = 9
 		}
 		can_convert_from = {
@@ -61,7 +61,7 @@ equipment_modules = {
 
 		add_stats = {
 			build_cost_ic = 1.85
-			fuel_consumption = 3.8
+			fuel_consumption = 3.3
 			maximum_speed = 10.5
 		}
 		can_convert_from = {
@@ -104,7 +104,7 @@ equipment_modules = {
 
 		add_stats = {
 			build_cost_ic = 2.14
-			fuel_consumption = 4.4
+			fuel_consumption = 3.9
 			maximum_speed = 12
 		}
 		can_convert_from = {
@@ -147,7 +147,7 @@ equipment_modules = {
 
 		add_stats = {
 			build_cost_ic = 2.525
-			fuel_consumption = 5
+			fuel_consumption = 4.5
 			maximum_speed = 13.25
 		}
 		can_convert_from = {
@@ -190,7 +190,7 @@ equipment_modules = {
 
 		add_stats = {
 			build_cost_ic = 3.2075
-			fuel_consumption = 5.6
+			fuel_consumption = 5.1
 			maximum_speed = 14.75
 		}
 		can_convert_from = {
@@ -233,7 +233,7 @@ equipment_modules = {
 
 		add_stats = {
 			build_cost_ic = 3.5
-			fuel_consumption = 6.2
+			fuel_consumption = 5.7
 			maximum_speed = 16.25
 		}
 		can_convert_from = {
@@ -276,7 +276,7 @@ equipment_modules = {
 
 		add_stats = {
 			build_cost_ic = 4.085
-			fuel_consumption = 6.6
+			fuel_consumption = 6.1
 			maximum_speed = 17.75
 		}
 		can_convert_from = {
@@ -319,7 +319,7 @@ equipment_modules = {
 
 		add_stats = {
 			build_cost_ic = 4.67
-			fuel_consumption = 7
+			fuel_consumption = 6.5
 			maximum_speed = 19.25
 		}
 		can_convert_from = {
@@ -362,7 +362,7 @@ equipment_modules = {
 
 		add_stats = {
 			build_cost_ic = 5.255
-			fuel_consumption = 7.5
+			fuel_consumption = 7.0
 			maximum_speed = 20.75
 		}
 		can_convert_from = {


### PR DESCRIPTION
Updated fuel consumption values for various tank modules.

Upon R3d Kn19h7's suggestion in devchat, requested all diesel tank modules reduce fuel consumption by -0.5 per generation. Please ping them for more clarification if needed! Thank you : )

### Changes
**Please describe the scope of the changes for this pull request.**

Closes #<issue number here>