### PR TITLE
Changes to French Targeting Pod Tech

### DIFF
--- a/history/countries/FRA - France.txt
+++ b/history/countries/FRA - France.txt
@@ -980,7 +980,6 @@ capital = 56
 			special_mad_2 = 1
 			tgp_recon_1 = 1
 			tgp_recon_2 = 1
-			tgp_recon_3 = 1
 		}
 		create_equipment_variant = {
 			name = "Mirage IVR"
@@ -1031,7 +1030,7 @@ capital = 56
 				avionics_type_slot = avionics_manned_2
 				wingform_type_slot = wing_swept
 				special_slot_type_1 = spec_countermeasures_2
-				special_slot_type_2 = spec_tgp_3
+				special_slot_type_2 = spec_tgp_1
 			}
 			obsolete = yes
 			icon = "gfx/interface/technologies/FRA/AIR/MR1.dds"


### PR DESCRIPTION
As per Guy, MD's Vietnam Associate's suggestions:

France in 2000 starts with 2025 Targeting Pod Tech, suggested fix is to remove from France history files

Tester reports 4 planes: Mirage F1CT, Mirage 5, CM-170, and Alpha Jet as having spec_tgp_3 modern targeting pods. 

Fixed Mirage F1CT, but am unable to find the level 3 Targeting pods. I'm considering this only a partial fix. If anyone can help me find the other 3 plane's targeting pods I'd appreciate it! (I could be uber blind too)

### Changes
**Please describe the scope of the changes for this pull request.**

Closes #<issue number here>