### PR TITLE
Add special_forces attribute to A_L_arm_Bat

### DIFF
--- a/common/units/MD_land_units.txt
+++ b/common/units/MD_land_units.txt
@@ -1205,6 +1205,7 @@ sub_units = {
 	A_L_arm_Bat = {
 		sprite = MD_medium_armor
 		map_icon_category = armored
+		special_forces = yes
 		priority = 20
 		active = no
 		ai_priority = 3


### PR DESCRIPTION
Request from R3d Kn19h7:
"This should make airborne light tanks now count towards SF cap and to show up under Airborne instead of Armor. "

### Changes
**Please describe the scope of the changes for this pull request.**

Closes #<issue number here>