### PR TITLE
Ranger combat width increase from 2 to 3

### DIFF
--- a/common/units/MD_land_units.txt
+++ b/common/units/MD_land_units.txt
@@ -1470,7 +1470,7 @@ sub_units = {
 			category_rcon_ranger #new
 		}
 
-		combat_width = 2
+		combat_width = 3
 
 		#Size Definitions
 		max_strength = 15


### PR DESCRIPTION
As per Dooalot the Sigillite [MD]'s wishes:
Increased Ranger Combat Width from 2 to 3 to match standard Infantry width

### Changes
**Please describe the scope of the changes for this pull request.**

Closes #<issue number here>