### PR TITLE
Set the in-game version banner from --version before upload

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -417,6 +417,10 @@ python3 tools/publishing/publish_workshop.py beta --base-ref v1.12.3b
 
 The script uses `git log --diff-filter=ACM` to determine which files changed, copies the full repo, then prunes unchanged files before uploading. `descriptor.mod` and `thumbnail.png` are always included.
 
+#### Version String
+
+`--version X.Y.Z` rewrites `version=` in the uploaded `descriptor.mod` and the `VERSION_MD_LOADING` / `VERSION_MD` banner in every `localisation/*/MD_frontend_l_*.yml` inside the staging copy. The repo's own files are never touched. Without `--version`, both keep the value already committed.
+
 ### What Gets Excluded
 
 The following are automatically excluded from all uploads:
@@ -436,6 +440,7 @@ Use `--exclude PATTERN` to add extra exclusions, or `--no-default-excludes` to s
 | `--mod-id ID`           | Override the default Workshop mod ID                                   |
 | `--exclude PATTERN`     | Extra exclude pattern (repeatable)                                     |
 | `--no-default-excludes` | Skip the built-in exclude list                                         |
+| `--version VERSION`     | Override the uploaded version (descriptor.mod and in-game banner)      |
 
 ### Workshop Mod IDs
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -419,7 +419,7 @@ The script uses `git log --diff-filter=ACM` to determine which files changed, co
 
 #### Version String
 
-`--version X.Y.Z` rewrites `version=` in the uploaded `descriptor.mod` and the `VERSION_MD_LOADING` / `VERSION_MD` banner in every `localisation/*/MD_frontend_l_*.yml` inside the staging copy. The repo's own files are never touched. Without `--version`, both keep the value already committed.
+`--version X.Y.Z` rewrites `version=` in the uploaded `descriptor.mod` and the `VERSION_MD_LOADING` / `VERSION_MD` banner in every `localisation/*/MD_frontend_l_*.yml` inside the staging copy. A leading `v` is ignored. A diff publish carries those files even when they are not part of the diff, so the banner always matches the upload. The repo's own files are never touched. Without `--version`, both keep the value already committed.
 
 ### What Gets Excluded
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -419,7 +419,15 @@ The script uses `git log --diff-filter=ACM` to determine which files changed, co
 
 #### Version String
 
-`--version X.Y.Z` rewrites `version=` in the uploaded `descriptor.mod` and the `VERSION_MD_LOADING` / `VERSION_MD` banner in every `localisation/*/MD_frontend_l_*.yml` inside the staging copy. A leading `v` is ignored. A diff publish carries those files even when they are not part of the diff, so the banner always matches the upload. The repo's own files are never touched. Without `--version`, both keep the value already committed.
+`--version X.Y.Z` rewrites `version=` in the uploaded `descriptor.mod` and
+both version banner keys in all ten production frontend locale files inside the
+staging copy. Accepted values are `X.Y.Z`, legacy suffixes such as `X.Y.Zb` or
+`X.Y.Zrc1`, and SemVer prereleases such as `X.Y.Z-beta.5`. One leading `v` or
+`V` is optional. A diff publish with `--version` carries all ten banner files
+even when they are not part of the diff. Without `--version`, a diff publish
+prunes them as usual. Missing, excluded, duplicate, or malformed banners abort
+before upload rather than uploading a mismatch. The repo's own files are never
+touched.
 
 ### What Gets Excluded
 
@@ -440,7 +448,7 @@ Use `--exclude PATTERN` to add extra exclusions, or `--no-default-excludes` to s
 | `--mod-id ID`           | Override the default Workshop mod ID                                   |
 | `--exclude PATTERN`     | Extra exclude pattern (repeatable)                                     |
 | `--no-default-excludes` | Skip the built-in exclude list                                         |
-| `--version VERSION`     | Override the uploaded version (descriptor.mod and in-game banner)      |
+| `--version VERSION`     | Override the uploaded version. Invalid or incomplete banners abort.    |
 
 ### Workshop Mod IDs
 

--- a/tools/publishing/publish_workshop.py
+++ b/tools/publishing/publish_workshop.py
@@ -9,8 +9,9 @@ Usage:
   STEAM_USERNAME=MyUser publish_workshop.py beta --full
 
 Username is read from --username or the STEAM_USERNAME env var.
---version rewrites version= in descriptor.mod for this upload only; omit
-to ship whatever version is currently committed in the repo.
+--version rewrites version= in descriptor.mod and the in-game version banner
+(VERSION_MD_LOADING / VERSION_MD) for this upload only; omit to ship whatever
+version is currently committed in the repo.
 """
 
 import argparse
@@ -447,6 +448,14 @@ def patch_descriptor(
         print("  version:        (unchanged — using repo descriptor.mod value)")
 
 
+def frontend_loc_files(mod_dir: Path) -> set[str]:
+    """Repo-relative paths of the frontend localisation files carrying the banner."""
+    return {
+        path.relative_to(mod_dir).as_posix()
+        for path in mod_dir.glob("localisation/*/MD_frontend_l_*.yml")
+    }
+
+
 def patch_frontend_version(mod_dir: Path, version: str) -> None:
     """Point the in-game version banner at the version being uploaded.
 
@@ -455,17 +464,18 @@ def patch_frontend_version(mod_dir: Path, version: str) -> None:
     hand. Only the version token is replaced; labels, translations, and the
     " DEV" suffix survive.
     """
-    loc_files = sorted(mod_dir.glob("localisation/*/MD_frontend_l_*.yml"))
+    loc_files = sorted(frontend_loc_files(mod_dir))
     matched = 0
     updated = 0
-    for loc_file in loc_files:
+    for rel in loc_files:
+        loc_file = mod_dir / rel
         lines = loc_file.read_text(encoding="utf-8").splitlines(keepends=True)
         changed = False
         for i, line in enumerate(lines):
             if line.split(":", 1)[0].strip() not in VERSION_LOC_KEYS:
                 continue
             matched += 1
-            replaced = VERSION_TOKEN.sub(f"v{version}", line, count=1)
+            replaced = VERSION_TOKEN.sub(lambda _match: f"v{version}", line, count=1)
             if replaced != line:
                 lines[i] = replaced
                 changed = True
@@ -717,8 +727,9 @@ def main() -> None:
     parser.add_argument("--mod-id", help="Override the Workshop mod ID")
     parser.add_argument(
         "--version",
-        help='Override version= in descriptor.mod (e.g. "1.12.3"). '
-        "Leave unset to ship the value already committed in the repo.",
+        help="Override version= in descriptor.mod and the in-game version banner "
+        '(e.g. "1.12.3"; a leading "v" is ignored). Leave unset to ship the '
+        "value already committed in the repo.",
     )
     parser.add_argument(
         "--exclude",
@@ -752,6 +763,11 @@ def main() -> None:
     username = args.username
     if not username:
         sys.exit("ERROR: No username. Pass --username or set STEAM_USERNAME.")
+
+    # A leading "v" is a display convention, not part of the version value.
+    version = args.version
+    if version and version[:1] in ("v", "V"):
+        version = version[1:]
 
     mod_id = args.mod_id or MOD_IDS[args.target]
     excludes = set() if args.no_default_excludes else set(DEFAULT_EXCLUDES)
@@ -788,16 +804,19 @@ def main() -> None:
                     "ERROR: No publishable mod files changed after excludes. "
                     "Use --full or adjust --exclude / --no-default-excludes."
                 )
+            if version:
+                # The banner lives in files a diff upload would otherwise drop.
+                publishable_changed |= frontend_loc_files(mod_dir)
             prune_unchanged(mod_dir, publishable_changed, verbose=args.verbose)
         else:
             mod_dir = copy_repo(tmp, excludes)
 
         # Rewrite descriptor.mod so the shipped copy matches this target.
-        patch_descriptor(mod_dir, MOD_NAMES[args.target], mod_id, args.version)
+        patch_descriptor(mod_dir, MOD_NAMES[args.target], mod_id, version)
 
         # Keep the menu/loading-screen version in step with the upload.
-        if args.version:
-            patch_frontend_version(mod_dir, args.version)
+        if version:
+            patch_frontend_version(mod_dir, version)
 
         # Validate required files exist
         validate_mod_files(mod_dir)

--- a/tools/publishing/publish_workshop.py
+++ b/tools/publishing/publish_workshop.py
@@ -16,6 +16,7 @@ to ship whatever version is currently committed in the repo.
 import argparse
 import fnmatch
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -42,6 +43,12 @@ MOD_NAMES = {
     "beta": "Millennium Dawn: A Beta Test Mod",
     "test": "MD Test",
 }
+
+# Localisation keys that render the version in the loading screen and main menu.
+VERSION_LOC_KEYS = {"VERSION_MD_LOADING", "VERSION_MD"}
+
+# An existing version token inside those values, e.g. v2.0.0 or v1.12.3b.
+VERSION_TOKEN = re.compile(r"v\d+(?:\.\d+)*(?:[A-Za-z]\w*)?")
 
 # Files that must always be included (even if unchanged in diff mode).
 ALWAYS_KEEP = {"descriptor.mod", "thumbnail.png"}
@@ -440,6 +447,45 @@ def patch_descriptor(
         print("  version:        (unchanged — using repo descriptor.mod value)")
 
 
+def patch_frontend_version(mod_dir: Path, version: str) -> None:
+    """Point the in-game version banner at the version being uploaded.
+
+    VERSION_MD_LOADING and VERSION_MD are baked into every locale's frontend
+    localisation, so they keep showing whichever version was last bumped by
+    hand. Only the version token is replaced; labels, translations, and the
+    " DEV" suffix survive.
+    """
+    loc_files = sorted(mod_dir.glob("localisation/*/MD_frontend_l_*.yml"))
+    matched = 0
+    updated = 0
+    for loc_file in loc_files:
+        lines = loc_file.read_text(encoding="utf-8").splitlines(keepends=True)
+        changed = False
+        for i, line in enumerate(lines):
+            if line.split(":", 1)[0].strip() not in VERSION_LOC_KEYS:
+                continue
+            matched += 1
+            replaced = VERSION_TOKEN.sub(f"v{version}", line, count=1)
+            if replaced != line:
+                lines[i] = replaced
+                changed = True
+        if changed:
+            with loc_file.open("w", encoding="utf-8", newline="") as handle:
+                handle.write("".join(lines))
+            updated += 1
+
+    if not matched:
+        print(
+            "  WARNING: no VERSION_MD_LOADING/VERSION_MD keys found under "
+            "localisation/; version banner left unchanged"
+        )
+        return
+    print(
+        f"  Version banner: v{version} "
+        f"({updated}/{len(loc_files)} frontend files rewritten)"
+    )
+
+
 def steam_login(steamcmd: Path, username: str) -> None:
     """Log in to Steam interactively to cache credentials before uploading."""
     print(f"  Logging in to Steam as '{username}'...")
@@ -748,6 +794,10 @@ def main() -> None:
 
         # Rewrite descriptor.mod so the shipped copy matches this target.
         patch_descriptor(mod_dir, MOD_NAMES[args.target], mod_id, args.version)
+
+        # Keep the menu/loading-screen version in step with the upload.
+        if args.version:
+            patch_frontend_version(mod_dir, args.version)
 
         # Validate required files exist
         validate_mod_files(mod_dir)

--- a/tools/publishing/publish_workshop.py
+++ b/tools/publishing/publish_workshop.py
@@ -10,8 +10,10 @@ Usage:
 
 Username is read from --username or the STEAM_USERNAME env var.
 --version rewrites version= in descriptor.mod and the in-game version banner
-(VERSION_MD_LOADING / VERSION_MD) for this upload only; omit to ship whatever
-version is currently committed in the repo.
+(VERSION_MD_LOADING / VERSION_MD) for this upload only. Accepted values are
+X.Y.Z, legacy suffixes such as X.Y.Zb or X.Y.Zrc1, and SemVer prereleases such
+as X.Y.Z-beta.5. An optional leading v or V is ignored; omit the flag to ship
+whatever version is currently committed in the repo.
 """
 
 import argparse
@@ -46,10 +48,34 @@ MOD_NAMES = {
 }
 
 # Localisation keys that render the version in the loading screen and main menu.
-VERSION_LOC_KEYS = {"VERSION_MD_LOADING", "VERSION_MD"}
+VERSION_LOC_KEYS = ("VERSION_MD_LOADING", "VERSION_MD")
 
-# An existing version token inside those values, e.g. v2.0.0 or v1.12.3b.
-VERSION_TOKEN = re.compile(r"v\d+(?:\.\d+)*(?:[A-Za-z]\w*)?")
+# The production frontend banners are intentionally a fixed set. A missing or
+# excluded locale must fail the publish instead of silently uploading a mismatch.
+FRONTEND_LOCALES = (
+    "braz_por",
+    "english",
+    "french",
+    "german",
+    "japanese",
+    "korean",
+    "polish",
+    "russian",
+    "simp_chinese",
+    "spanish",
+)
+
+# An existing version token inside those values, e.g. v2.0.0, v1.12.3b, or
+# v2.0.0-beta.1. Boundaries prevent a partial match from leaving a suffix behind.
+_VERSION_NUMBER = r"(?:0|[1-9][0-9]*)"
+_PRERELEASE_IDENTIFIER = r"(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z][0-9A-Za-z-]*)"
+_VERSION_BODY = (
+    rf"{_VERSION_NUMBER}\.{_VERSION_NUMBER}\.{_VERSION_NUMBER}"
+    rf"(?:(?:[A-Za-z][A-Za-z0-9]*)|"
+    rf"(?:-(?:{_PRERELEASE_IDENTIFIER})(?:\.(?:{_PRERELEASE_IDENTIFIER}))*))?"
+)
+VERSION_TOKEN = re.compile(rf"(?<![A-Za-z0-9_])v{_VERSION_BODY}(?![A-Za-z0-9_.+-])")
+VERSION_VALUE = re.compile(rf"[vV]?{_VERSION_BODY}")
 
 # Files that must always be included (even if unchanged in diff mode).
 ALWAYS_KEEP = {"descriptor.mod", "thumbnail.png"}
@@ -113,6 +139,19 @@ ANYWHERE_EXCLUDES = {
 }
 
 DEFAULT_EXCLUDES = ROOT_ONLY_EXCLUDES | ANYWHERE_EXCLUDES
+
+
+def normalize_version(value: str | None) -> str | None:
+    """Validate a publish version and remove one optional leading ``v``."""
+    if value is None:
+        return None
+    if VERSION_VALUE.fullmatch(value) is None:
+        raise SystemExit(
+            f"ERROR: Invalid version {value!r}. Expected X.Y.Z, a legacy suffix "
+            "such as X.Y.Zb, or a SemVer prerelease such as X.Y.Z-beta.5. "
+            "One optional leading v or V is accepted."
+        )
+    return value[1:] if value[:1] in ("v", "V") else value
 
 
 def elapsed_str(start: float) -> str:
@@ -448,48 +487,63 @@ def patch_descriptor(
         print("  version:        (unchanged — using repo descriptor.mod value)")
 
 
-def frontend_loc_files(mod_dir: Path) -> set[str]:
-    """Repo-relative paths of the frontend localisation files carrying the banner."""
-    return {
-        path.relative_to(mod_dir).as_posix()
-        for path in mod_dir.glob("localisation/*/MD_frontend_l_*.yml")
-    }
+def frontend_loc_files(mod_dir: Path) -> tuple[Path, ...]:
+    """Return the fixed set of frontend localisation paths for a mod copy."""
+    return tuple(
+        mod_dir / "localisation" / locale / f"MD_frontend_l_{locale}.yml"
+        for locale in FRONTEND_LOCALES
+    )
 
 
 def patch_frontend_version(mod_dir: Path, version: str) -> None:
-    """Point the in-game version banner at the version being uploaded.
+    """Point every required in-game version banner at the uploaded version."""
+    loc_files = frontend_loc_files(mod_dir)
+    validated: list[tuple[Path, list[str]]] = []
 
-    VERSION_MD_LOADING and VERSION_MD are baked into every locale's frontend
-    localisation, so they keep showing whichever version was last bumped by
-    hand. Only the version token is replaced; labels, translations, and the
-    " DEV" suffix survive.
-    """
-    loc_files = sorted(frontend_loc_files(mod_dir))
-    matched = 0
+    for loc_file in loc_files:
+        rel = loc_file.relative_to(mod_dir).as_posix()
+        if not loc_file.is_file():
+            raise SystemExit(
+                f"ERROR: Missing expected frontend localisation file: {rel}"
+            )
+
+        with loc_file.open("r", encoding="utf-8", newline="") as handle:
+            lines = handle.read().splitlines(keepends=True)
+        for key in VERSION_LOC_KEYS:
+            key_lines = [
+                (i, line)
+                for i, line in enumerate(lines)
+                if line.split(":", 1)[0].strip() == key
+            ]
+            if len(key_lines) != 1:
+                raise SystemExit(
+                    f"ERROR: Invalid version banner in {rel}: {key} must appear "
+                    f"exactly once (found {len(key_lines)})"
+                )
+            _, key_line = key_lines[0]
+            token_count = len(VERSION_TOKEN.findall(key_line))
+            if token_count != 1:
+                raise SystemExit(
+                    f"ERROR: Invalid version banner in {rel}: {key} must contain "
+                    f"exactly one version token (found {token_count})"
+                )
+        validated.append((loc_file, lines))
+
     updated = 0
-    for rel in loc_files:
-        loc_file = mod_dir / rel
-        lines = loc_file.read_text(encoding="utf-8").splitlines(keepends=True)
-        changed = False
-        for i, line in enumerate(lines):
-            if line.split(":", 1)[0].strip() not in VERSION_LOC_KEYS:
-                continue
-            matched += 1
-            replaced = VERSION_TOKEN.sub(lambda _match: f"v{version}", line, count=1)
-            if replaced != line:
-                lines[i] = replaced
-                changed = True
-        if changed:
+    for loc_file, lines in validated:
+        patched = [
+            (
+                VERSION_TOKEN.sub(lambda _match: f"v{version}", line, count=1)
+                if line.split(":", 1)[0].strip() in VERSION_LOC_KEYS
+                else line
+            )
+            for line in lines
+        ]
+        if patched != lines:
             with loc_file.open("w", encoding="utf-8", newline="") as handle:
-                handle.write("".join(lines))
+                handle.write("".join(patched))
             updated += 1
 
-    if not matched:
-        print(
-            "  WARNING: no VERSION_MD_LOADING/VERSION_MD keys found under "
-            "localisation/; version banner left unchanged"
-        )
-        return
     print(
         f"  Version banner: v{version} "
         f"({updated}/{len(loc_files)} frontend files rewritten)"
@@ -727,9 +781,10 @@ def main() -> None:
     parser.add_argument("--mod-id", help="Override the Workshop mod ID")
     parser.add_argument(
         "--version",
-        help="Override version= in descriptor.mod and the in-game version banner "
-        '(e.g. "1.12.3"; a leading "v" is ignored). Leave unset to ship the '
-        "value already committed in the repo.",
+        help="Override version= and the in-game banner. Accepts X.Y.Z, legacy "
+        "suffixes (X.Y.Zb or X.Y.Zrc1), or SemVer prereleases "
+        "(X.Y.Z-beta.5); one leading v/V is optional. Missing, excluded, or "
+        "malformed banners abort before upload.",
     )
     parser.add_argument(
         "--exclude",
@@ -764,10 +819,8 @@ def main() -> None:
     if not username:
         sys.exit("ERROR: No username. Pass --username or set STEAM_USERNAME.")
 
-    # A leading "v" is a display convention, not part of the version value.
-    version = args.version
-    if version and version[:1] in ("v", "V"):
-        version = version[1:]
+    # Validate before copying or staging anything.
+    version = normalize_version(args.version)
 
     mod_id = args.mod_id or MOD_IDS[args.target]
     excludes = set() if args.no_default_excludes else set(DEFAULT_EXCLUDES)
@@ -806,7 +859,10 @@ def main() -> None:
                 )
             if version:
                 # The banner lives in files a diff upload would otherwise drop.
-                publishable_changed |= frontend_loc_files(mod_dir)
+                publishable_changed |= {
+                    loc_file.relative_to(mod_dir).as_posix()
+                    for loc_file in frontend_loc_files(mod_dir)
+                }
             prune_unchanged(mod_dir, publishable_changed, verbose=args.verbose)
         else:
             mod_dir = copy_repo(tmp, excludes)

--- a/tools/tests/publishing_coverage_test.py
+++ b/tools/tests/publishing_coverage_test.py
@@ -382,62 +382,53 @@ def test_patch_frontend_version_rejects_a_missing_file_without_partial_writes(tm
     )
 
 
-def test_patch_frontend_version_rejects_a_missing_key(tmp_path):
+@pytest.mark.parametrize(
+    "malformation, expected_error",
+    [
+        (
+            (b" VERSION_MD: ", b" VERSION_REMOVED: "),
+            "VERSION_MD must appear exactly once",
+        ),
+        (
+            (
+                b' VERSION_MD: "Millennium Dawn: A Modern Day v2.0.0 DEV"\n',
+                b' VERSION_MD: "Millennium Dawn: A Modern Day v2.0.0 DEV"\n'
+                b' VERSION_MD: "Duplicate v2.0.0"\n',
+            ),
+            "VERSION_MD must appear exactly once",
+        ),
+        (
+            (
+                b' VERSION_MD_LOADING: "Version: v2.0.0 DEV"',
+                b' VERSION_MD_LOADING: "Version: missing DEV"',
+            ),
+            "VERSION_MD_LOADING must contain exactly one",
+        ),
+        (
+            (
+                b' VERSION_MD_LOADING: "Version: v2.0.0 DEV"',
+                b' VERSION_MD_LOADING: "Version: v2.0.0 and v2.0.0 DEV"',
+            ),
+            "VERSION_MD_LOADING must contain exactly one",
+        ),
+    ],
+    ids=[
+        "missing_key",
+        "duplicate_key",
+        "zero_replaceable_tokens",
+        "multiple_replaceable_tokens",
+    ],
+)
+def test_patch_frontend_version_rejects_malformed_frontend_banners(
+    tmp_path, malformation, expected_error
+):
     paths = _write_frontend_tree(tmp_path)
     english = tmp_path / "localisation/english/MD_frontend_l_english.yml"
-    english.write_bytes(
-        english.read_bytes().replace(b" VERSION_MD: ", b" VERSION_REMOVED: ")
-    )
+    old, new = malformation
+    english.write_bytes(english.read_bytes().replace(old, new))
     before = {path: path.read_bytes() for path in paths}
 
-    with pytest.raises(SystemExit, match="VERSION_MD must appear exactly once"):
-        pw.patch_frontend_version(tmp_path, "1.2.3")
-
-    assert all(path.read_bytes() == data for path, data in before.items())
-
-
-def test_patch_frontend_version_rejects_a_duplicate_key(tmp_path):
-    paths = _write_frontend_tree(tmp_path)
-    english = tmp_path / "localisation/english/MD_frontend_l_english.yml"
-    with english.open("ab") as handle:
-        handle.write(b' VERSION_MD: "Duplicate v2.0.0"\n')
-    before = {path: path.read_bytes() for path in paths}
-
-    with pytest.raises(SystemExit, match="VERSION_MD must appear exactly once"):
-        pw.patch_frontend_version(tmp_path, "1.2.3")
-
-    assert all(path.read_bytes() == data for path, data in before.items())
-
-
-def test_patch_frontend_version_rejects_zero_replaceable_tokens(tmp_path):
-    paths = _write_frontend_tree(tmp_path)
-    english = tmp_path / "localisation/english/MD_frontend_l_english.yml"
-    english.write_bytes(
-        english.read_bytes().replace(
-            b' VERSION_MD_LOADING: "Version: v2.0.0 DEV"',
-            b' VERSION_MD_LOADING: "Version: missing DEV"',
-        )
-    )
-    before = {path: path.read_bytes() for path in paths}
-
-    with pytest.raises(SystemExit, match="VERSION_MD_LOADING must contain exactly one"):
-        pw.patch_frontend_version(tmp_path, "1.2.3")
-
-    assert all(path.read_bytes() == data for path, data in before.items())
-
-
-def test_patch_frontend_version_rejects_multiple_replaceable_tokens(tmp_path):
-    paths = _write_frontend_tree(tmp_path)
-    english = tmp_path / "localisation/english/MD_frontend_l_english.yml"
-    english.write_bytes(
-        english.read_bytes().replace(
-            b' VERSION_MD_LOADING: "Version: v2.0.0 DEV"',
-            b' VERSION_MD_LOADING: "Version: v2.0.0 and v2.0.0 DEV"',
-        )
-    )
-    before = {path: path.read_bytes() for path in paths}
-
-    with pytest.raises(SystemExit, match="VERSION_MD_LOADING must contain exactly one"):
+    with pytest.raises(SystemExit, match=expected_error):
         pw.patch_frontend_version(tmp_path, "1.2.3")
 
     assert all(path.read_bytes() == data for path, data in before.items())

--- a/tools/tests/publishing_coverage_test.py
+++ b/tools/tests/publishing_coverage_test.py
@@ -185,6 +185,83 @@ def test_patch_descriptor_missing_file_warns(tmp_path, capsys):
 
 
 # ---------------------------------------------------------------------------
+# Frontend version banner patching
+# ---------------------------------------------------------------------------
+
+
+def _frontend_loc(mod_dir, lang, body):
+    path = mod_dir / "localisation" / lang / f"MD_frontend_l_{lang}.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\xef\xbb\xbf" + body.encode("utf-8"))
+    return path
+
+
+def test_patch_frontend_version_rewrites_every_locale(tmp_path, capsys):
+    body = (
+        "l_english:\n"
+        ' VERSION_MD_LOADING: "Version: v2.0.0 DEV"\n'
+        ' VERSION_MD: "Millennium Dawn: A Modern Day v2.0.0 DEV"\n'
+        ' VERSION_MD_DATE: "Release Date: 11th September 2026"\n'
+    )
+    paths = [_frontend_loc(tmp_path, lang, body) for lang in ("english", "german")]
+
+    pw.patch_frontend_version(tmp_path, "1.2.3")
+
+    for path in paths:
+        raw = path.read_bytes()
+        assert raw.startswith(b"\xef\xbb\xbf"), "BOM must survive"
+        text = raw.decode("utf-8")
+        assert 'VERSION_MD_LOADING: "Version: v1.2.3 DEV"' in text
+        assert 'VERSION_MD: "Millennium Dawn: A Modern Day v1.2.3 DEV"' in text
+        assert "v2.0.0" not in text
+        assert 'VERSION_MD_DATE: "Release Date: 11th September 2026"' in text
+    assert "2/2 frontend files rewritten" in capsys.readouterr().out
+
+
+def test_patch_frontend_version_keeps_translated_text(tmp_path):
+    korean = _frontend_loc(
+        tmp_path,
+        "korean",
+        "l_korean:\n"
+        ' VERSION_MD_LOADING: "버전: v2.0.0 DEV"\n'
+        ' VERSION_MD: "Millennium Dawn: A Modern Day v2.0.0 DEV"\n',
+    )
+    chinese = _frontend_loc(
+        tmp_path,
+        "simp_chinese",
+        'l_simp_chinese:\n VERSION_MD_LOADING: "版本：v2.0.0 开发版"\n',
+    )
+
+    pw.patch_frontend_version(tmp_path, "2.1.0")
+
+    assert 'VERSION_MD_LOADING: "버전: v2.1.0 DEV"' in korean.read_text(
+        encoding="utf-8"
+    )
+    assert 'VERSION_MD_LOADING: "版本：v2.1.0 开发版"' in chinese.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_patch_frontend_version_warns_when_no_keys(tmp_path, capsys):
+    _frontend_loc(tmp_path, "english", "l_english:\n KEY: value\n")
+
+    pw.patch_frontend_version(tmp_path, "1.0.0")
+
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_patch_frontend_version_is_a_noop_when_already_current(tmp_path):
+    path = _frontend_loc(
+        tmp_path, "english", 'l_english:\n VERSION_MD: "Version: v1.2.3 DEV"\n'
+    )
+    before = path.read_bytes()
+
+    pw.patch_frontend_version(tmp_path, "1.2.3")
+
+    assert path.read_bytes() == before
+
+
+# ---------------------------------------------------------------------------
 # VDF generation
 # ---------------------------------------------------------------------------
 
@@ -864,6 +941,55 @@ def test_main_full_publish_patches_the_descriptor_then_uploads(tmp_path, monkeyp
     assert seen["mod_id"] == "2777133449"
     assert seen["changenote"] == "notes"
     assert seen["verbose"] is False
+
+
+def _main_frontend_text(tmp_path, monkeypatch, *args):
+    _prepare_full_main(tmp_path, monkeypatch, *args)
+    seen = {}
+
+    def fake_copy(dest_parent, _excludes):
+        mod_dir = dest_parent / "mod"
+        loc = mod_dir / "localisation" / "english" / "MD_frontend_l_english.yml"
+        loc.parent.mkdir(parents=True)
+        loc.write_bytes(
+            b'\xef\xbb\xbfl_english:\n VERSION_MD_LOADING: "Version: v2.0.0 DEV"\n'
+        )
+        write_text(mod_dir / "descriptor.mod", 'name="Old"\nversion="0.1"\n')
+        (mod_dir / "thumbnail.png").write_bytes(b"\x89PNG")
+        return mod_dir
+
+    def fake_publish(mod_dir, *_args, **_kwargs):
+        seen["frontend"] = (
+            mod_dir / "localisation" / "english" / "MD_frontend_l_english.yml"
+        ).read_text(encoding="utf-8")
+
+    monkeypatch.setattr(pw, "copy_repo", fake_copy)
+    monkeypatch.setattr(pw, "publish", fake_publish)
+    pw.main()
+    return seen["frontend"]
+
+
+def test_main_patches_the_version_banner_when_version_given(tmp_path, monkeypatch):
+    frontend = _main_frontend_text(
+        tmp_path,
+        monkeypatch,
+        "test",
+        "--full",
+        "--username",
+        "u",
+        "--version",
+        "1.2.3",
+    )
+
+    assert 'VERSION_MD_LOADING: "Version: v1.2.3 DEV"' in frontend
+
+
+def test_main_leaves_the_version_banner_alone_without_version(tmp_path, monkeypatch):
+    frontend = _main_frontend_text(
+        tmp_path, monkeypatch, "test", "--full", "--username", "u"
+    )
+
+    assert 'VERSION_MD_LOADING: "Version: v2.0.0 DEV"' in frontend
 
 
 def test_main_no_default_excludes_is_honoured(tmp_path, monkeypatch):

--- a/tools/tests/publishing_coverage_test.py
+++ b/tools/tests/publishing_coverage_test.py
@@ -189,6 +189,23 @@ def test_patch_descriptor_missing_file_warns(tmp_path, capsys):
 # ---------------------------------------------------------------------------
 
 
+EXPECTED_FRONTEND_PATHS = {
+    "localisation/braz_por/MD_frontend_l_braz_por.yml",
+    "localisation/english/MD_frontend_l_english.yml",
+    "localisation/french/MD_frontend_l_french.yml",
+    "localisation/german/MD_frontend_l_german.yml",
+    "localisation/japanese/MD_frontend_l_japanese.yml",
+    "localisation/korean/MD_frontend_l_korean.yml",
+    "localisation/polish/MD_frontend_l_polish.yml",
+    "localisation/russian/MD_frontend_l_russian.yml",
+    "localisation/simp_chinese/MD_frontend_l_simp_chinese.yml",
+    "localisation/spanish/MD_frontend_l_spanish.yml",
+}
+
+
+EXPECTED_VERSION_LOC_KEYS = ("VERSION_MD_LOADING", "VERSION_MD")
+
+
 def _frontend_loc(mod_dir, lang, body):
     path = mod_dir / "localisation" / lang / f"MD_frontend_l_{lang}.yml"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -196,14 +213,45 @@ def _frontend_loc(mod_dir, lang, body):
     return path
 
 
-def test_patch_frontend_version_rewrites_every_locale(tmp_path, capsys):
-    body = (
-        "l_english:\n"
-        ' VERSION_MD_LOADING: "Version: v2.0.0 DEV"\n'
-        ' VERSION_MD: "Millennium Dawn: A Modern Day v2.0.0 DEV"\n'
+def test_frontend_loc_files_returns_the_fixed_locale_set(tmp_path):
+    assert {
+        path.relative_to(tmp_path).as_posix()
+        for path in pw.frontend_loc_files(tmp_path)
+    } == EXPECTED_FRONTEND_PATHS
+
+
+def _frontend_body(lang, version="2.0.0"):
+    loading = "Version: v{version} DEV"
+    main = "Millennium Dawn: A Modern Day v{version} DEV"
+    if lang == "korean":
+        loading = "버전: v{version} DEV"
+    elif lang == "simp_chinese":
+        loading = "版本：v{version} 开发版"
+        main = "千禧黎明：现代之日 v{version} 开发版"
+    return (
+        f"l_{lang}:\n"
+        f' VERSION_MD_LOADING: "{loading.format(version=version)}"\n'
+        f' VERSION_MD: "{main.format(version=version)}"\n'
         ' VERSION_MD_DATE: "Release Date: 11th September 2026"\n'
     )
-    paths = [_frontend_loc(tmp_path, lang, body) for lang in ("english", "german")]
+
+
+def _write_frontend_tree(mod_dir, version="2.0.0", bodies=None):
+    bodies = bodies or {}
+    paths = []
+    for rel in sorted(EXPECTED_FRONTEND_PATHS):
+        path = mod_dir / rel
+        lang = path.parent.name
+        paths.append(
+            _frontend_loc(
+                mod_dir, lang, bodies.get(lang, _frontend_body(lang, version))
+            )
+        )
+    return paths
+
+
+def test_patch_frontend_version_rewrites_every_locale(tmp_path, capsys):
+    paths = _write_frontend_tree(tmp_path)
 
     pw.patch_frontend_version(tmp_path, "1.2.3")
 
@@ -211,78 +259,217 @@ def test_patch_frontend_version_rewrites_every_locale(tmp_path, capsys):
         raw = path.read_bytes()
         assert raw.startswith(b"\xef\xbb\xbf"), "BOM must survive"
         text = raw.decode("utf-8")
-        assert 'VERSION_MD_LOADING: "Version: v1.2.3 DEV"' in text
-        assert 'VERSION_MD: "Millennium Dawn: A Modern Day v1.2.3 DEV"' in text
-        assert "v2.0.0" not in text
+        for key in EXPECTED_VERSION_LOC_KEYS:
+            matches = [
+                line
+                for line in text.splitlines()
+                if line.split(":", 1)[0].strip() == key
+            ]
+            assert len(matches) == 1
+            assert matches[0].count("v1.2.3") == 1
+            assert "v2.0.0" not in matches[0]
         assert 'VERSION_MD_DATE: "Release Date: 11th September 2026"' in text
-    assert "2/2 frontend files rewritten" in capsys.readouterr().out
+    assert "10/10 frontend files rewritten" in capsys.readouterr().out
 
 
 def test_patch_frontend_version_keeps_translated_text(tmp_path):
-    korean = _frontend_loc(
-        tmp_path,
-        "korean",
-        "l_korean:\n"
-        ' VERSION_MD_LOADING: "버전: v2.0.0 DEV"\n'
-        ' VERSION_MD: "Millennium Dawn: A Modern Day v2.0.0 DEV"\n',
-    )
-    chinese = _frontend_loc(
-        tmp_path,
-        "simp_chinese",
-        'l_simp_chinese:\n VERSION_MD_LOADING: "版本：v2.0.0 开发版"\n',
-    )
+    _write_frontend_tree(tmp_path)
 
     pw.patch_frontend_version(tmp_path, "2.1.0")
 
-    assert 'VERSION_MD_LOADING: "버전: v2.1.0 DEV"' in korean.read_text(
+    korean = (tmp_path / "localisation/korean/MD_frontend_l_korean.yml").read_text(
         encoding="utf-8"
     )
-    assert 'VERSION_MD_LOADING: "版本：v2.1.0 开发版"' in chinese.read_text(
-        encoding="utf-8"
+    chinese = (
+        tmp_path / "localisation/simp_chinese/MD_frontend_l_simp_chinese.yml"
+    ).read_text(encoding="utf-8")
+    assert 'VERSION_MD_LOADING: "버전: v2.1.0 DEV"' in korean
+    assert 'VERSION_MD: "Millennium Dawn: A Modern Day v2.1.0 DEV"' in korean
+    assert 'VERSION_MD_LOADING: "版本：v2.1.0 开发版"' in chinese
+    assert 'VERSION_MD: "千禧黎明：现代之日 v2.1.0 开发版"' in chinese
+
+
+def test_patch_frontend_version_replaces_a_complete_prerelease_token(tmp_path):
+    _write_frontend_tree(tmp_path, version="2.0.0-beta.1")
+
+    pw.patch_frontend_version(tmp_path, "2.0.0-beta.5")
+
+    for rel in EXPECTED_FRONTEND_PATHS:
+        text = (tmp_path / rel).read_text(encoding="utf-8")
+        assert text.count("v2.0.0-beta.5") == 2
+        assert "v2.0.0-beta.1" not in text
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("v2.0.0", ["v2.0.0"]),
+        ("v1.12.3b", ["v1.12.3b"]),
+        ("v2.0.0-beta.1", ["v2.0.0-beta.1"]),
+    ],
+)
+def test_version_token_matches_complete_supported_formats(source, expected):
+    assert pw.VERSION_TOKEN.findall(source) == expected
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "xv2.0.0",
+        "_v2.0.0",
+        "v2.0.0+build.1",
+        "v2.0.0_beta",
+    ],
+)
+def test_version_token_rejects_partial_matches(source):
+    assert pw.VERSION_TOKEN.findall(source) == []
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, None),
+        ("0.0.0", "0.0.0"),
+        ("1.2.3", "1.2.3"),
+        ("1.2.3rc1", "1.2.3rc1"),
+        (
+            "123456789012345678901234567890.987654321098765432109876543210.111111111111111111111111111111",
+            "123456789012345678901234567890.987654321098765432109876543210.111111111111111111111111111111",
+        ),
+        ("v1.12.3b", "1.12.3b"),
+        ("V2.0.0-beta.5", "2.0.0-beta.5"),
+    ],
+)
+def test_normalize_version_accepts_supported_formats(value, expected):
+    assert pw.normalize_version(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "v",
+        " 1.2.3",
+        "1.2.3 ",
+        '"1.2.3"',
+        "1.2.3\\1",
+        "1.2",
+        "1.2.3-",
+        "1.2.3-beta..1",
+        "-1.2.3",
+        "01.2.3",
+        "1.2.3\n",
+        "1.2.3\x00",
+    ],
+)
+def test_normalize_version_rejects_malformed_values(value):
+    with pytest.raises(SystemExit, match=r"^ERROR: Invalid version") as exc_info:
+        pw.normalize_version(value)
+    assert "One optional leading v or V is accepted" in str(exc_info.value)
+
+
+def test_patch_frontend_version_rejects_a_missing_file_without_partial_writes(tmp_path):
+    paths = _write_frontend_tree(tmp_path)
+    before = {path: path.read_bytes() for path in paths}
+    missing = tmp_path / "localisation/english/MD_frontend_l_english.yml"
+    missing.unlink()
+
+    with pytest.raises(SystemExit, match="Missing expected frontend localisation file"):
+        pw.patch_frontend_version(tmp_path, "1.2.3")
+
+    assert all(
+        path.read_bytes() == data for path, data in before.items() if path != missing
     )
 
 
-def test_patch_frontend_version_warns_when_no_keys(tmp_path, capsys):
-    _frontend_loc(tmp_path, "english", "l_english:\n KEY: value\n")
-
-    pw.patch_frontend_version(tmp_path, "1.0.0")
-
-    assert "WARNING" in capsys.readouterr().out
-
-
-def test_patch_frontend_version_is_a_noop_when_already_current(tmp_path):
-    path = _frontend_loc(
-        tmp_path, "english", 'l_english:\n VERSION_MD: "Version: v1.2.3 DEV"\n'
+def test_patch_frontend_version_rejects_a_missing_key(tmp_path):
+    paths = _write_frontend_tree(tmp_path)
+    english = tmp_path / "localisation/english/MD_frontend_l_english.yml"
+    english.write_bytes(
+        english.read_bytes().replace(b" VERSION_MD: ", b" VERSION_REMOVED: ")
     )
-    before = path.read_bytes()
+    before = {path: path.read_bytes() for path in paths}
+
+    with pytest.raises(SystemExit, match="VERSION_MD must appear exactly once"):
+        pw.patch_frontend_version(tmp_path, "1.2.3")
+
+    assert all(path.read_bytes() == data for path, data in before.items())
+
+
+def test_patch_frontend_version_rejects_a_duplicate_key(tmp_path):
+    paths = _write_frontend_tree(tmp_path)
+    english = tmp_path / "localisation/english/MD_frontend_l_english.yml"
+    with english.open("ab") as handle:
+        handle.write(b' VERSION_MD: "Duplicate v2.0.0"\n')
+    before = {path: path.read_bytes() for path in paths}
+
+    with pytest.raises(SystemExit, match="VERSION_MD must appear exactly once"):
+        pw.patch_frontend_version(tmp_path, "1.2.3")
+
+    assert all(path.read_bytes() == data for path, data in before.items())
+
+
+def test_patch_frontend_version_rejects_zero_replaceable_tokens(tmp_path):
+    paths = _write_frontend_tree(tmp_path)
+    english = tmp_path / "localisation/english/MD_frontend_l_english.yml"
+    english.write_bytes(
+        english.read_bytes().replace(
+            b' VERSION_MD_LOADING: "Version: v2.0.0 DEV"',
+            b' VERSION_MD_LOADING: "Version: missing DEV"',
+        )
+    )
+    before = {path: path.read_bytes() for path in paths}
+
+    with pytest.raises(SystemExit, match="VERSION_MD_LOADING must contain exactly one"):
+        pw.patch_frontend_version(tmp_path, "1.2.3")
+
+    assert all(path.read_bytes() == data for path, data in before.items())
+
+
+def test_patch_frontend_version_rejects_multiple_replaceable_tokens(tmp_path):
+    paths = _write_frontend_tree(tmp_path)
+    english = tmp_path / "localisation/english/MD_frontend_l_english.yml"
+    english.write_bytes(
+        english.read_bytes().replace(
+            b' VERSION_MD_LOADING: "Version: v2.0.0 DEV"',
+            b' VERSION_MD_LOADING: "Version: v2.0.0 and v2.0.0 DEV"',
+        )
+    )
+    before = {path: path.read_bytes() for path in paths}
+
+    with pytest.raises(SystemExit, match="VERSION_MD_LOADING must contain exactly one"):
+        pw.patch_frontend_version(tmp_path, "1.2.3")
+
+    assert all(path.read_bytes() == data for path, data in before.items())
+
+
+def test_patch_frontend_version_is_a_byte_for_byte_noop_for_same_version(tmp_path):
+    paths = _write_frontend_tree(tmp_path, version="1.2.3")
+    before = {path: path.read_bytes() for path in paths}
 
     pw.patch_frontend_version(tmp_path, "1.2.3")
 
-    assert path.read_bytes() == before
+    assert all(path.read_bytes() == data for path, data in before.items())
 
 
-def test_patch_frontend_version_treats_the_version_literally(tmp_path):
-    path = _frontend_loc(
-        tmp_path, "english", 'l_english:\n VERSION_MD: "Version: v2.0.0 DEV"\n'
-    )
+def test_real_frontend_files_match_the_fixed_production_locale_contract():
+    localisation = pw.REPO_ROOT / "localisation"
+    actual = {
+        path.relative_to(pw.REPO_ROOT).as_posix()
+        for path in localisation.glob("*/MD_frontend_l_*.yml")
+    }
+    assert actual == EXPECTED_FRONTEND_PATHS
+    assert tuple(pw.VERSION_LOC_KEYS) == EXPECTED_VERSION_LOC_KEYS
 
-    pw.patch_frontend_version(tmp_path, "2.0\\1")
-
-    assert 'VERSION_MD: "Version: v2.0\\1 DEV"' in path.read_text(encoding="utf-8")
-
-
-def test_real_frontend_files_expose_a_patchable_version_banner():
-    loc_files = sorted((pw.REPO_ROOT / "localisation").glob("*/MD_frontend_l_*.yml"))
-
-    assert loc_files, "expected frontend localisation files in the repo"
-    for path in loc_files:
+    for rel in sorted(EXPECTED_FRONTEND_PATHS):
+        path = pw.REPO_ROOT / rel
         lines = path.read_text(encoding="utf-8").splitlines()
-        for key in pw.VERSION_LOC_KEYS:
+        for key in EXPECTED_VERSION_LOC_KEYS:
             matches = [line for line in lines if line.split(":", 1)[0].strip() == key]
-            assert len(matches) == 1, f"{path.name}: expected exactly one {key}"
-            assert pw.VERSION_TOKEN.search(
-                matches[0]
-            ), f"{path.name}: {key} has no version token for the publisher to replace"
+            assert len(matches) == 1, f"{rel}: expected exactly one {key}"
+            assert (
+                len(pw.VERSION_TOKEN.findall(matches[0])) == 1
+            ), f"{rel}: {key} must have exactly one complete version token"
 
 
 # ---------------------------------------------------------------------------
@@ -941,11 +1128,16 @@ def test_main_full_publish_patches_the_descriptor_then_uploads(tmp_path, monkeyp
             mod_dir / "descriptor.mod",
             'name="Old"\nversion="0.1"\nremote_file_id="0"\n',
         )
+        _write_frontend_tree(mod_dir)
         (mod_dir / "thumbnail.png").write_bytes(b"\x89PNG")
         return mod_dir
 
     def fake_publish(mod_dir, username, mod_id, changenote, verbose=False):
         seen["descriptor"] = (mod_dir / "descriptor.mod").read_text(encoding="utf-8")
+        seen["frontend_paths"] = {
+            path.relative_to(mod_dir).as_posix()
+            for path in mod_dir.glob("localisation/*/MD_frontend_l_*.yml")
+        }
         seen["username"] = username
         seen["mod_id"] = mod_id
         seen["changenote"] = changenote
@@ -961,6 +1153,7 @@ def test_main_full_publish_patches_the_descriptor_then_uploads(tmp_path, monkeyp
     assert 'name="MD Test"' in seen["descriptor"]
     assert 'remote_file_id="2777133449"' in seen["descriptor"]
     assert 'version="1.2.3"' in seen["descriptor"]
+    assert seen["frontend_paths"] == EXPECTED_FRONTEND_PATHS
     assert seen["username"] == "uploader"
     assert seen["mod_id"] == "2777133449"
     assert seen["changenote"] == "notes"
@@ -971,13 +1164,12 @@ def _main_staged(tmp_path, monkeypatch, *args):
     _prepare_full_main(tmp_path, monkeypatch, *args)
     seen = {}
 
-    def fake_copy(dest_parent, _excludes):
+    def fake_copy(dest_parent, excludes):
         mod_dir = dest_parent / "mod"
-        loc = mod_dir / "localisation" / "english" / "MD_frontend_l_english.yml"
-        loc.parent.mkdir(parents=True)
-        loc.write_bytes(
-            b'\xef\xbb\xbfl_english:\n VERSION_MD_LOADING: "Version: v2.0.0 DEV"\n'
-        )
+        mod_dir.mkdir()
+        _write_frontend_tree(mod_dir)
+        if "english" in excludes:
+            (mod_dir / "localisation/english/MD_frontend_l_english.yml").unlink()
         write_text(mod_dir / "descriptor.mod", 'name="Old"\nversion="0.1"\n')
         (mod_dir / "thumbnail.png").write_bytes(b"\x89PNG")
         return mod_dir
@@ -986,6 +1178,10 @@ def _main_staged(tmp_path, monkeypatch, *args):
         seen["frontend"] = (
             mod_dir / "localisation" / "english" / "MD_frontend_l_english.yml"
         ).read_text(encoding="utf-8")
+        seen["frontend_paths"] = {
+            path.relative_to(mod_dir).as_posix()
+            for path in mod_dir.glob("localisation/*/MD_frontend_l_*.yml")
+        }
         seen["descriptor"] = (mod_dir / "descriptor.mod").read_text(encoding="utf-8")
 
     monkeypatch.setattr(pw, "copy_repo", fake_copy)
@@ -1004,11 +1200,8 @@ def _main_diff_staged(tmp_path, monkeypatch, changed, *args):
 
     def fake_copy(dest_parent, _excludes):
         mod_dir = dest_parent / "mod"
-        loc = mod_dir / "localisation" / "english" / "MD_frontend_l_english.yml"
-        loc.parent.mkdir(parents=True)
-        loc.write_bytes(
-            b'\xef\xbb\xbfl_english:\n VERSION_MD_LOADING: "Version: v2.0.0 DEV"\n'
-        )
+        mod_dir.mkdir()
+        _write_frontend_tree(mod_dir)
         (mod_dir / "events").mkdir()
         write_text(mod_dir / "events" / "foo.txt", "changed\n")
         write_text(mod_dir / "descriptor.mod", 'name="Old"\nversion="0.1"\n')
@@ -1018,6 +1211,10 @@ def _main_diff_staged(tmp_path, monkeypatch, changed, *args):
     def fake_publish(mod_dir, *_args, **_kwargs):
         loc = mod_dir / "localisation" / "english" / "MD_frontend_l_english.yml"
         seen["banner"] = loc.read_text(encoding="utf-8") if loc.exists() else ""
+        seen["frontend_paths"] = {
+            path.relative_to(mod_dir).as_posix()
+            for path in mod_dir.glob("localisation/*/MD_frontend_l_*.yml")
+        }
         seen["kept_event"] = (mod_dir / "events" / "foo.txt").exists()
 
     monkeypatch.setattr(pw, "copy_repo", fake_copy)
@@ -1039,12 +1236,14 @@ def test_main_patches_the_version_banner_when_version_given(tmp_path, monkeypatc
     )
 
     assert 'VERSION_MD_LOADING: "Version: v1.2.3 DEV"' in staged["frontend"]
+    assert staged["frontend_paths"] == EXPECTED_FRONTEND_PATHS
 
 
 def test_main_leaves_the_version_banner_alone_without_version(tmp_path, monkeypatch):
     staged = _main_staged(tmp_path, monkeypatch, "test", "--full", "--username", "u")
 
     assert 'VERSION_MD_LOADING: "Version: v2.0.0 DEV"' in staged["frontend"]
+    assert staged["frontend_paths"] == EXPECTED_FRONTEND_PATHS
 
 
 def test_main_ignores_a_leading_v_in_the_version(tmp_path, monkeypatch):
@@ -1061,6 +1260,41 @@ def test_main_ignores_a_leading_v_in_the_version(tmp_path, monkeypatch):
 
     assert 'VERSION_MD_LOADING: "Version: v1.2.3 DEV"' in staged["frontend"]
     assert 'version="1.2.3"' in staged["descriptor"]
+
+
+def test_main_version_validation_happens_before_copy(tmp_path, monkeypatch):
+    _prepare_full_main(
+        tmp_path,
+        monkeypatch,
+        "test",
+        "--full",
+        "--username",
+        "u",
+        "--version",
+        r"1.2.3\\1",
+    )
+    monkeypatch.setattr(pw, "copy_repo", lambda *_args: pytest.fail("copy_repo called"))
+
+    with pytest.raises(SystemExit, match=r"^ERROR: Invalid version"):
+        pw.main()
+
+
+def test_main_excludes_a_required_locale_instead_of_uploading_a_mismatch(
+    tmp_path, monkeypatch
+):
+    with pytest.raises(SystemExit, match="Missing expected frontend localisation file"):
+        _main_staged(
+            tmp_path,
+            monkeypatch,
+            "test",
+            "--full",
+            "--username",
+            "u",
+            "--version",
+            "1.2.3",
+            "--exclude",
+            "english",
+        )
 
 
 def test_main_diff_publish_with_version_ships_the_patched_banner(
@@ -1080,8 +1314,9 @@ def test_main_diff_publish_with_version_ships_the_patched_banner(
     )
 
     assert 'VERSION_MD_LOADING: "Version: v1.2.3 DEV"' in staged["banner"]
+    assert staged["frontend_paths"] == EXPECTED_FRONTEND_PATHS
     assert staged["kept_event"] is True
-    assert "1/1 frontend files rewritten" in capsys.readouterr().out
+    assert "10/10 frontend files rewritten" in capsys.readouterr().out
 
 
 def test_main_diff_publish_without_version_still_prunes_the_banner(
@@ -1099,6 +1334,7 @@ def test_main_diff_publish_without_version_still_prunes_the_banner(
     )
 
     assert staged["banner"] == ""
+    assert staged["frontend_paths"] == set()
     assert staged["kept_event"] is True
 
 

--- a/tools/tests/publishing_coverage_test.py
+++ b/tools/tests/publishing_coverage_test.py
@@ -261,6 +261,30 @@ def test_patch_frontend_version_is_a_noop_when_already_current(tmp_path):
     assert path.read_bytes() == before
 
 
+def test_patch_frontend_version_treats_the_version_literally(tmp_path):
+    path = _frontend_loc(
+        tmp_path, "english", 'l_english:\n VERSION_MD: "Version: v2.0.0 DEV"\n'
+    )
+
+    pw.patch_frontend_version(tmp_path, "2.0\\1")
+
+    assert 'VERSION_MD: "Version: v2.0\\1 DEV"' in path.read_text(encoding="utf-8")
+
+
+def test_real_frontend_files_expose_a_patchable_version_banner():
+    loc_files = sorted((pw.REPO_ROOT / "localisation").glob("*/MD_frontend_l_*.yml"))
+
+    assert loc_files, "expected frontend localisation files in the repo"
+    for path in loc_files:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for key in pw.VERSION_LOC_KEYS:
+            matches = [line for line in lines if line.split(":", 1)[0].strip() == key]
+            assert len(matches) == 1, f"{path.name}: expected exactly one {key}"
+            assert pw.VERSION_TOKEN.search(
+                matches[0]
+            ), f"{path.name}: {key} has no version token for the publisher to replace"
+
+
 # ---------------------------------------------------------------------------
 # VDF generation
 # ---------------------------------------------------------------------------
@@ -943,7 +967,7 @@ def test_main_full_publish_patches_the_descriptor_then_uploads(tmp_path, monkeyp
     assert seen["verbose"] is False
 
 
-def _main_frontend_text(tmp_path, monkeypatch, *args):
+def _main_staged(tmp_path, monkeypatch, *args):
     _prepare_full_main(tmp_path, monkeypatch, *args)
     seen = {}
 
@@ -962,15 +986,48 @@ def _main_frontend_text(tmp_path, monkeypatch, *args):
         seen["frontend"] = (
             mod_dir / "localisation" / "english" / "MD_frontend_l_english.yml"
         ).read_text(encoding="utf-8")
+        seen["descriptor"] = (mod_dir / "descriptor.mod").read_text(encoding="utf-8")
 
     monkeypatch.setattr(pw, "copy_repo", fake_copy)
     monkeypatch.setattr(pw, "publish", fake_publish)
     pw.main()
-    return seen["frontend"]
+    return seen
+
+
+def _main_diff_staged(tmp_path, monkeypatch, changed, *args):
+    monkeypatch.setattr(sys, "argv", ["publish_workshop.py", *args])
+    monkeypatch.setattr(pw, "get_deleted_files", lambda _ref: set())
+    monkeypatch.setattr(pw, "get_changed_files", lambda _ref: set(changed))
+    monkeypatch.setattr(pw.tempfile, "mkdtemp", lambda prefix="": str(tmp_path / "pub"))
+    (tmp_path / "pub").mkdir()
+    seen = {}
+
+    def fake_copy(dest_parent, _excludes):
+        mod_dir = dest_parent / "mod"
+        loc = mod_dir / "localisation" / "english" / "MD_frontend_l_english.yml"
+        loc.parent.mkdir(parents=True)
+        loc.write_bytes(
+            b'\xef\xbb\xbfl_english:\n VERSION_MD_LOADING: "Version: v2.0.0 DEV"\n'
+        )
+        (mod_dir / "events").mkdir()
+        write_text(mod_dir / "events" / "foo.txt", "changed\n")
+        write_text(mod_dir / "descriptor.mod", 'name="Old"\nversion="0.1"\n')
+        (mod_dir / "thumbnail.png").write_bytes(b"\x89PNG")
+        return mod_dir
+
+    def fake_publish(mod_dir, *_args, **_kwargs):
+        loc = mod_dir / "localisation" / "english" / "MD_frontend_l_english.yml"
+        seen["banner"] = loc.read_text(encoding="utf-8") if loc.exists() else ""
+        seen["kept_event"] = (mod_dir / "events" / "foo.txt").exists()
+
+    monkeypatch.setattr(pw, "copy_repo", fake_copy)
+    monkeypatch.setattr(pw, "publish", fake_publish)
+    pw.main()
+    return seen
 
 
 def test_main_patches_the_version_banner_when_version_given(tmp_path, monkeypatch):
-    frontend = _main_frontend_text(
+    staged = _main_staged(
         tmp_path,
         monkeypatch,
         "test",
@@ -981,15 +1038,86 @@ def test_main_patches_the_version_banner_when_version_given(tmp_path, monkeypatc
         "1.2.3",
     )
 
-    assert 'VERSION_MD_LOADING: "Version: v1.2.3 DEV"' in frontend
+    assert 'VERSION_MD_LOADING: "Version: v1.2.3 DEV"' in staged["frontend"]
 
 
 def test_main_leaves_the_version_banner_alone_without_version(tmp_path, monkeypatch):
-    frontend = _main_frontend_text(
-        tmp_path, monkeypatch, "test", "--full", "--username", "u"
+    staged = _main_staged(tmp_path, monkeypatch, "test", "--full", "--username", "u")
+
+    assert 'VERSION_MD_LOADING: "Version: v2.0.0 DEV"' in staged["frontend"]
+
+
+def test_main_ignores_a_leading_v_in_the_version(tmp_path, monkeypatch):
+    staged = _main_staged(
+        tmp_path,
+        monkeypatch,
+        "test",
+        "--full",
+        "--username",
+        "u",
+        "--version",
+        "v1.2.3",
     )
 
-    assert 'VERSION_MD_LOADING: "Version: v2.0.0 DEV"' in frontend
+    assert 'VERSION_MD_LOADING: "Version: v1.2.3 DEV"' in staged["frontend"]
+    assert 'version="1.2.3"' in staged["descriptor"]
+
+
+def test_main_diff_publish_with_version_ships_the_patched_banner(
+    tmp_path, monkeypatch, capsys
+):
+    staged = _main_diff_staged(
+        tmp_path,
+        monkeypatch,
+        {"events/foo.txt"},
+        "beta",
+        "--base-ref",
+        "v1",
+        "--username",
+        "u",
+        "--version",
+        "1.2.3",
+    )
+
+    assert 'VERSION_MD_LOADING: "Version: v1.2.3 DEV"' in staged["banner"]
+    assert staged["kept_event"] is True
+    assert "1/1 frontend files rewritten" in capsys.readouterr().out
+
+
+def test_main_diff_publish_without_version_still_prunes_the_banner(
+    tmp_path, monkeypatch
+):
+    staged = _main_diff_staged(
+        tmp_path,
+        monkeypatch,
+        {"events/foo.txt"},
+        "beta",
+        "--base-ref",
+        "v1",
+        "--username",
+        "u",
+    )
+
+    assert staged["banner"] == ""
+    assert staged["kept_event"] is True
+
+
+def test_main_diff_publish_with_version_still_refuses_an_empty_diff(
+    tmp_path, monkeypatch
+):
+    with pytest.raises(SystemExit, match="No publishable mod files changed"):
+        _main_diff_staged(
+            tmp_path,
+            monkeypatch,
+            {"tools/secret.py"},
+            "beta",
+            "--base-ref",
+            "v1",
+            "--username",
+            "u",
+            "--version",
+            "1.2.3",
+        )
 
 
 def test_main_no_default_excludes_is_honoured(tmp_path, monkeypatch):

--- a/tools/tests/validation/validate_events_call_scan_test.py
+++ b/tools/tests/validation/validate_events_call_scan_test.py
@@ -307,12 +307,31 @@ def test_undefined_fire_reported_once_per_id(tmp_path):
     assert v._issues[0].category == "undefined-event-fire"
 
 
-def test_event_fire_caches_are_reused(tmp_path):
+def test_event_fire_views_share_typed_scan(tmp_path, monkeypatch):
+    monkeypatch.setenv("MD_NO_CACHE", "1")
     _write(tmp_path, "common/f.txt", "x = { country_event = foo.1 }\n")
+    calls = []
+    original = V.scan_typed_event_fires
+
+    def wrapped(args):
+        calls.append(args[0])
+        return original(args)
+
+    monkeypatch.setattr(V, "scan_typed_event_fires", wrapped)
+    monkeypatch.setattr(
+        V,
+        "scan_event_fires",
+        lambda _args: pytest.fail("untyped fires must reuse the typed scan"),
+    )
     v = _validator(tmp_path)
-    assert v._get_event_fires() is v._get_event_fires()
-    assert v._get_typed_event_fires() is v._get_typed_event_fires()
-    assert [f[0] for f in v._get_event_fires()] == ["foo.1"]
+    fires = v._get_event_fires()
+    typed_fires = v._get_typed_event_fires()
+
+    assert calls == [str(tmp_path / "common" / "f.txt")]
+    assert fires is v._get_event_fires()
+    assert typed_fires is v._get_typed_event_fires()
+    assert fires == [(eid, filename, line) for eid, _, filename, line in typed_fires]
+    assert [f[0] for f in fires] == ["foo.1"]
     assert v._rel_posix(str(tmp_path / "common" / "f.txt")) == "common/f.txt"
 
 
@@ -321,13 +340,13 @@ def test_event_fires_hit_disk_cache_across_instances(tmp_path, monkeypatch):
     _write(tmp_path, "common/f.txt", "x = { country_event = foo.1 }\n")
     first = _validator(tmp_path)._get_event_fires()
     calls = []
-    original = V.scan_event_fires
+    original = V.scan_typed_event_fires
 
     def wrapped(args):
         calls.append(args[0])
         return original(args)
 
-    monkeypatch.setattr(V, "scan_event_fires", wrapped)
+    monkeypatch.setattr(V, "scan_typed_event_fires", wrapped)
     second = _validator(tmp_path)._get_event_fires()
     assert calls == []
     assert [row[0] for row in second] == [row[0] for row in first]

--- a/tools/validation/validate_events.py
+++ b/tools/validation/validate_events.py
@@ -565,11 +565,6 @@ def _stat_cached_scan(mod_path: str, namespace: str, filename: str, scanner):
     )
 
 
-def _cached_scan_event_fires(args: Tuple[str, str]) -> List[Tuple[str, str, int]]:
-    filename, mod_path = args
-    return _stat_cached_scan(mod_path, "events.fires", filename, scan_event_fires)
-
-
 def _cached_scan_typed_event_fires(
     args: Tuple[str, str],
 ) -> List[Tuple[str, str, str, int]]:
@@ -1129,14 +1124,12 @@ class Validator(BaseValidator):
 
     def _get_event_fires(self) -> List[Tuple[str, str, int]]:
         """Every literal event fire in the mod as (event_id, file, line)."""
-        if self._fires_cache is not None:
-            return self._fires_cache
-        fires: List[Tuple[str, str, int]] = []
-        args = [(path, self.mod_path) for path, _ in self._get_fire_scan_args()]
-        for result in self._pool_map(_cached_scan_event_fires, args, chunksize=30):
-            fires.extend(result)
-        self._fires_cache = fires
-        return fires
+        if self._fires_cache is None:
+            self._fires_cache = [
+                (eid, filename, line)
+                for eid, _call_type, filename, line in self._get_typed_event_fires()
+            ]
+        return self._fires_cache
 
     def _get_typed_event_fires(self) -> List[Tuple[str, str, str, int]]:
         """Every literal event fire with its call keyword."""


### PR DESCRIPTION
## Bottom line

`--version` now rewrites `descriptor.mod` and both in-game version banners across all ten production locales for full and diff publishes. Invalid versions, missing or excluded locale files, duplicate keys, and malformed banner tokens abort before upload instead of shipping mismatched metadata.

## How

The publisher accepts the project real version formats (`X.Y.Z`, legacy suffixes such as `X.Y.Zb` / `X.Y.Zrc1`, and prereleases such as `X.Y.Z-beta.5`) with one optional leading `v` or `V`. Complete token boundaries prevent prerelease suffixes from being left behind.

All ten expected frontend paths are fixed independently of filesystem discovery. Each file must contain exactly one `VERSION_MD_LOADING` and one `VERSION_MD`, each with exactly one complete version token. The whole set is validated before any file is written. Diff publishes keep these files only when `--version` is supplied; normal pruning and the empty-diff guard are unchanged. Repo files are never touched.

The unchanged 15-second staged-validator gate exposed a duplicate cold full-tree event-fire scan. Event validation now derives the untyped fire view from the existing typed scan, preserving full call-site coverage while avoiding the second pass over 6,435 files.

Tests cover full and diff payloads, real locale layout, BOM and translated text preservation, atomic failures, exclude conflicts, malformed input boundaries, legacy/prerelease tokens, same-version no-ops, and shared typed/untyped event-fire scans. Full suite: 4889 passed, 3 skipped. Focused publishing coverage: 99% with only unrelated defensive/entrypoint lines uncovered. Commit-stage hooks pass, including Ruff, Black, Pylint, mypy, Prettier, secrets, and encoding checks.

Closes #4023

BLUF