### PR TITLE
Reuse validator disk cache across checkout roots

### DIFF
--- a/tools/tests/core_runtime_coverage_test.py
+++ b/tools/tests/core_runtime_coverage_test.py
@@ -707,7 +707,7 @@ def test_cache_corruption_and_file_cache_lifecycle(tmp_path, monkeypatch):
     assert conn is not None
     conn.execute(
         "UPDATE entries SET value = ? WHERE namespace = ? AND key = ?",
-        (b"corrupt", "test", str(source)),
+        (b"corrupt", "test", cache._source_key(str(tmp_path), str(source))),
     )
     assert cache.per_file_cached(str(tmp_path), "test", str(source), compute) == {
         "value": 2

--- a/tools/tests/validation/disk_cache_test.py
+++ b/tools/tests/validation/disk_cache_test.py
@@ -2,6 +2,7 @@
 `MD_NO_CACHE` bypass."""
 
 import os
+import shutil
 
 import disk_cache
 import pytest
@@ -36,6 +37,44 @@ def _patch_helper_change(monkeypatch, namespace, helper_name):
         return original_read_bytes(path)
 
     monkeypatch.setattr(type(helper), "read_bytes", changed_read_bytes)
+
+
+def _close_cache_connections():
+    with disk_cache._conns_lock:
+        for key in list(disk_cache._conns):
+            conn = disk_cache._conns.pop(key)
+            try:
+                conn.close()
+            except (OSError, disk_cache.sqlite3.Error):
+                pass
+
+
+def _copy_cache(src, dst):
+    _close_cache_connections()
+    shutil.copytree(src / disk_cache._CACHE_DIR_NAME, dst / disk_cache._CACHE_DIR_NAME)
+
+
+def _two_identical_files(tmp_path, rel="common/x.txt", body="hello"):
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    for root in (first, second):
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    return first, second
+
+
+def _warm_content(root, content="hello", namespace="ns", rel="common/x.txt"):
+    calls = []
+
+    def compute():
+        calls.append(1)
+        return content
+
+    disk_cache.per_file_cached_by_content(
+        str(root), namespace, str(root / rel), content, compute
+    )
+    return calls, compute
 
 
 def test_code_fingerprints_are_scoped_to_owner_and_shared_code():
@@ -508,3 +547,232 @@ def test_clear_if_stale_keeps_a_fresh_cache(tmp_path):
 
     assert disk_cache.clear_if_stale(str(tmp_path), 7.0) is False
     assert disk_cache._marker_path(str(tmp_path)).exists()
+
+
+def test_source_key_is_relative_under_the_checkout(tmp_path):
+    source = tmp_path / "common" / "x.txt"
+    source.parent.mkdir()
+    source.write_text("hello", encoding="utf-8")
+
+    assert disk_cache._source_key(str(tmp_path), str(source)) == "common/x.txt"
+    assert disk_cache._source_key(str(tmp_path), "already/rel.txt") == (
+        "already/rel.txt"
+    )
+
+
+def test_code_fingerprint_ignores_checkout_root(tmp_path, monkeypatch):
+    first = tmp_path / "a" / "owner.py"
+    second = tmp_path / "b" / "owner.py"
+    first.parent.mkdir()
+    second.parent.mkdir()
+    first.write_text("same", encoding="utf-8")
+    second.write_text("same", encoding="utf-8")
+    disk_cache._FINGERPRINT_CACHE.clear()
+    monkeypatch.setattr(disk_cache, "_fingerprint_paths", lambda _ns: [first])
+    left = disk_cache._validator_code_fingerprint("ns")
+    disk_cache._FINGERPRINT_CACHE.clear()
+    monkeypatch.setattr(disk_cache, "_fingerprint_paths", lambda _ns: [second])
+    right = disk_cache._validator_code_fingerprint("ns")
+
+    assert left == right
+
+
+def test_copied_content_cache_hits_at_a_different_root(tmp_path):
+    first, second = _two_identical_files(tmp_path)
+    calls, compute = _warm_content(first)
+    _copy_cache(first, second)
+    disk_cache.per_file_cached_by_content(
+        str(second), "ns", str(second / "common" / "x.txt"), "hello", compute
+    )
+
+    assert calls == [1]
+    conn = disk_cache._connect(str(first))
+    assert conn is not None
+    keys = [row[0] for row in conn.execute("SELECT key FROM entries")]
+    assert keys == ["common/x.txt"]
+
+
+def test_modified_content_at_the_new_root_misses(tmp_path):
+    first, second = _two_identical_files(tmp_path)
+    calls, compute = _warm_content(first)
+    _copy_cache(first, second)
+    disk_cache.per_file_cached_by_content(
+        str(second), "ns", str(second / "common" / "x.txt"), "changed", compute
+    )
+
+    assert calls == [1, 1]
+
+
+def test_helper_change_still_invalidates_after_a_copy(tmp_path, monkeypatch):
+    first, second = _two_identical_files(tmp_path)
+    calls = []
+
+    def compute():
+        calls.append(1)
+        return "ok"
+
+    disk_cache._FINGERPRINT_CACHE.clear()
+    disk_cache.per_file_cached_by_content(
+        str(first),
+        "sprite_index.names",
+        str(first / "common" / "x.txt"),
+        "hello",
+        compute,
+    )
+    _copy_cache(first, second)
+    _patch_helper_change(
+        monkeypatch, "sprite_index.names", "validate_gfx_references.py"
+    )
+    disk_cache._FINGERPRINT_CACHE.clear()
+    disk_cache.per_file_cached_by_content(
+        str(second),
+        "sprite_index.names",
+        str(second / "common" / "x.txt"),
+        "hello",
+        compute,
+    )
+
+    assert calls == [1, 1]
+
+
+def test_deleted_tracked_file_invalidates_aggregate_after_a_copy(tmp_path):
+    first, second = _two_identical_files(tmp_path)
+    extra = first / "common" / "y.txt"
+    extra.write_text("y", encoding="utf-8")
+    (second / "common" / "y.txt").write_text("y", encoding="utf-8")
+    calls = []
+
+    def factory():
+        calls.append(1)
+        return "merged"
+
+    tracked_first = [str(first / "common" / "x.txt"), str(extra)]
+    disk_cache.aggregate_cached(str(first), "agg", tracked_first, factory)
+    _copy_cache(first, second)
+    (second / "common" / "y.txt").unlink()
+    disk_cache.aggregate_cached(
+        str(second), "agg", [str(second / "common" / "x.txt")], factory
+    )
+
+    assert calls == [1, 1]
+
+
+def test_embedded_checkout_paths_rehome_on_restore(tmp_path):
+    first, second = _two_identical_files(tmp_path)
+    src_first = str(first / "common" / "x.txt")
+    src_second = str(second / "common" / "x.txt")
+    disk_cache.per_file_cached_by_content(
+        str(first),
+        "ns",
+        src_first,
+        "hello",
+        lambda: {"file": src_first, "ok": True},
+    )
+    _copy_cache(first, second)
+    result = disk_cache.per_file_cached_by_content(
+        str(second),
+        "ns",
+        src_second,
+        "hello",
+        lambda: {"file": "miss", "ok": False},
+    )
+
+    assert result == {"file": src_second, "ok": True}
+
+
+def test_sprite_textures_rehome_and_do_not_store_absolute_paths(tmp_path):
+    first, second = _two_identical_files(tmp_path)
+    gfx_body = (
+        'spriteType = {\n\tname = "GFX_g"\n' '\ttexturefile = "gfx/art/g.dds"\n}\n'
+    )
+    for root in (first, second):
+        gfx = root / "interface" / "g.gfx"
+        gfx.parent.mkdir(parents=True)
+        gfx.write_text(gfx_body, encoding="utf-8")
+    index_first = sprite_index.build_sprite_texture_index(
+        str(first), include_vanilla=False
+    )
+    conn = disk_cache._connect(str(first))
+    assert conn is not None
+    row = conn.execute(
+        "SELECT value FROM entries WHERE namespace = ?",
+        ("sprite_index.textures",),
+    ).fetchone()
+    stored = disk_cache._unpack(str(first), row[0])
+    assert stored == [["GFX_g", "gfx/art/g.dds"]]
+    assert str(first) not in str(stored)
+    _copy_cache(first, second)
+    index_second = sprite_index.build_sprite_texture_index(
+        str(second), include_vanilla=False
+    )
+
+    assert index_first["GFX_g"] == os.path.join(str(first), "gfx", "art", "g.dds")
+    assert index_second["GFX_g"] == os.path.join(str(second), "gfx", "art", "g.dds")
+    assert str(first) not in index_second["GFX_g"]
+
+
+def test_vanilla_install_paths_do_not_leak_across_installs(tmp_path, monkeypatch):
+    first, second = _two_identical_files(tmp_path)
+    for root in (first, second):
+        (root / "interface").mkdir(parents=True, exist_ok=True)
+        (root / "interface" / "mod.gfx").write_text(
+            'spriteType = { name = "GFX_mod" texturefile = "gfx/mod.dds" }\n',
+            encoding="utf-8",
+        )
+    van_first = tmp_path / "van_a" / "interface" / "v.gfx"
+    van_second = tmp_path / "van_b" / "interface" / "v.gfx"
+    van_first.parent.mkdir(parents=True)
+    van_second.parent.mkdir(parents=True)
+    gfx_text = 'spriteType = { name = "GFX_van" texturefile = "gfx/van.dds" }\n'
+    van_first.write_text(gfx_text, encoding="utf-8")
+    van_second.write_text(gfx_text, encoding="utf-8")
+    monkeypatch.setattr(sprite_index, "_vanilla_gfx_files", lambda: [str(van_first)])
+    index_first = sprite_index.build_sprite_texture_index(
+        str(first), include_vanilla=True
+    )
+    _copy_cache(first, second)
+    monkeypatch.setattr(sprite_index, "_vanilla_gfx_files", lambda: [str(van_second)])
+    index_second = sprite_index.build_sprite_texture_index(
+        str(second), include_vanilla=True
+    )
+
+    assert index_first["GFX_van"].endswith(os.path.join("gfx", "van.dds"))
+    assert str(tmp_path / "van_a") in index_first["GFX_van"]
+    assert index_second["GFX_van"].endswith(os.path.join("gfx", "van.dds"))
+    assert str(tmp_path / "van_b") in index_second["GFX_van"]
+    assert str(tmp_path / "van_a") not in index_second["GFX_van"]
+
+
+def test_portable_key_and_rehome_edges(tmp_path):
+    old = str(tmp_path / "old")
+    new = str(tmp_path / "new")
+    posix_new = os.path.normpath(new).replace("\\", "/")
+    assert disk_cache._source_key(str(tmp_path), "") == ""
+    assert disk_cache._source_key(str(tmp_path), str(tmp_path)) == "."
+    outside = tmp_path.parent / "other.txt"
+    assert disk_cache._source_key(str(tmp_path), str(outside)) == os.path.normpath(
+        str(outside)
+    ).replace("\\", "/")
+    assert disk_cache._rehome_str(old, old, new) == posix_new
+    assert disk_cache._rehome_mod_paths([old + "/a.txt"], old, new) == [
+        os.path.join(new, "a.txt").replace("\\", "/")
+    ]
+    assert disk_cache._rehome_mod_paths((old + "/a.txt",), old, new) == (
+        os.path.join(new, "a.txt").replace("\\", "/"),
+    )
+    assert disk_cache._rehome_mod_paths({old + "/a.txt"}, old, new) == {
+        os.path.join(new, "a.txt").replace("\\", "/")
+    }
+    assert disk_cache._rehome_mod_paths(frozenset({old + "/a.txt"}), old, new) == (
+        frozenset({os.path.join(new, "a.txt").replace("\\", "/")})
+    )
+    from collections import namedtuple
+
+    rec = namedtuple("Rec", "path")
+    moved = disk_cache._rehome_mod_paths(rec(old + "/a.txt"), old, new)
+    assert moved.path == os.path.join(new, "a.txt").replace("\\", "/")
+    loop: list = []
+    loop.append(loop)
+    disk_cache._rehome_mod_paths(loop, old, new)
+    with pytest.raises(disk_cache.pickle.UnpicklingError):
+        disk_cache._unpack(str(tmp_path), disk_cache.pickle.dumps(("nope",)))

--- a/tools/validation/DISK_CACHE.md
+++ b/tools/validation/DISK_CACHE.md
@@ -20,6 +20,13 @@ disk_cache.aggregate_cached(mod_path, key, tracked_files, factory_fn)
 | `per_file_cached_by_content` | `(len, sha1(content))` + namespace       | One result per source file, keyed on content not mtime |
 | `aggregate_cached`           | `(mtime_ns, size)` of every tracked file | Merged result that depends on the whole tree           |
 
+Row keys are checkout-relative when the file lives under `mod_path`. Vanilla
+install paths stay absolute, so a different HOI4 copy does not reuse those rows.
+Each payload records the checkout root that wrote it. Restoring the cache at
+another root rehomes embedded checkout paths; it does not rewrite vanilla paths.
+Sprite texture entries store the `texturefile` relative path and join it to the
+current `.gfx` root after a hit, so they cannot point at another tree.
+
 `per_file_cached_by_content` is preferred on CI, where git checkouts reset mtimes and make the stat-based key miss every entry. Supply the already-read content string; no extra file read.
 
 Most validators use `per_file_cached_by_content` indirectly via `BaseValidator.parse_files_cached()`, which handles file collection, comment stripping, and caching in one call. Direct `disk_cache.*` calls are mainly for aggregate scans or pool-worker paths that operate outside the standard parse loop.
@@ -32,7 +39,7 @@ loading a stale or corrupt cache fall back to recomputing.
 
 ```
 .validation_cache/
-  v5/
+  v9/
     cache.db        # single SQLite db: one row per (namespace, key)
     cache.db-wal
     cache.db-shm

--- a/tools/validation/disk_cache.py
+++ b/tools/validation/disk_cache.py
@@ -5,6 +5,10 @@
 only re-scans files that changed. `per_file_cached_by_content` keys on a content
 hash instead (survives git checkouts that reset mtimes). `aggregate_cached`
 invalidates a single merged result when any contributing file's stat changes.
+Files under the checkout are keyed relative to `mod_path` so a copied cache can
+hit at another root. Each stored payload records that root and rehomes embedded
+paths on restore. Paths outside the checkout (a live vanilla install) stay
+absolute and do not reuse across installations.
 
 Storage is a single SQLite database at `.validation_cache/v<N>/cache.db`
 (gitignored). One row per `(namespace, key)`; re-writing an entry overwrites the
@@ -40,7 +44,9 @@ from shared_utils import write_text_under
 # scripted_params token cache after the 3-tuple → 4-tuple token format change
 # (the cache keys on file content, not validator source, so a format change in
 # the token shape requires a version bump to avoid stale 3-tuple entries).
-CACHE_VERSION = 8
+# v9 stores checkout-relative keys and records the checkout root on each
+# payload so embedded paths rehome when the cache is restored at another root.
+CACHE_VERSION = 9
 
 
 # Cache entries include the owning validator and shared cache/parser code so a
@@ -77,6 +83,8 @@ _VALIDATOR_NAMESPACES = {
 }
 
 _FINGERPRINT_CACHE: Dict[str, Tuple[Tuple[Tuple[str, int, int], ...], str]] = {}
+_TOOLS_ROOT = Path(__file__).resolve().parent.parent
+_CACHE_RECORD = "md.cache.v9"
 
 # These helpers are called inside cached computations, so their source changes
 # must invalidate the owning namespace without making unrelated namespaces cold.
@@ -87,6 +95,107 @@ _HELPER_DEPENDENCIES = {
     "oob_units": ("equipment_module_slots.py",),
     "sprite_index": ("validate_gfx_references.py",),
 }
+
+
+def _fingerprint_identity(path: Path) -> str:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return path.name
+    try:
+        return resolved.relative_to(_TOOLS_ROOT).as_posix()
+    except ValueError:
+        return path.name
+
+
+def _source_key(mod_path: str, source_path: str) -> str:
+    if not source_path:
+        return source_path
+    if not os.path.isabs(source_path):
+        return source_path.replace("\\", "/")
+    try:
+        rel = os.path.relpath(source_path, mod_path)
+    except ValueError:
+        return os.path.normpath(source_path).replace("\\", "/")
+    if rel == ".":
+        return "."
+    if rel.startswith(".."):
+        return os.path.normpath(source_path).replace("\\", "/")
+    return rel.replace("\\", "/")
+
+
+def _rehome_str(value: str, old_root: str, new_root: str) -> str:
+    old = os.path.normpath(old_root).replace("\\", "/")
+    new = os.path.normpath(new_root).replace("\\", "/")
+    current = value.replace("\\", "/")
+    if current == old:
+        if "/" in value and "\\" not in value:
+            return new
+        return os.path.normpath(new_root)
+    prefix = old.rstrip("/") + "/"
+    if not current.startswith(prefix):
+        return value
+    tail = current[len(prefix) :]
+    rehoused = os.path.join(new_root, *tail.split("/"))
+    if "/" in value and "\\" not in value:
+        return rehoused.replace("\\", "/")
+    return rehoused
+
+
+def _rehome_mod_paths(
+    obj: Any, old_root: str, new_root: str, _seen: Optional[set] = None
+) -> Any:
+    if obj is None or isinstance(obj, (int, float, bool, bytes, complex)):
+        return obj
+    if isinstance(obj, str):
+        return _rehome_str(obj, old_root, new_root)
+    if _seen is None:
+        _seen = set()
+    obj_id = id(obj)
+    if obj_id in _seen:
+        return obj
+    _seen.add(obj_id)
+    if isinstance(obj, dict):
+        return {
+            _rehome_mod_paths(key, old_root, new_root, _seen): _rehome_mod_paths(
+                value, old_root, new_root, _seen
+            )
+            for key, value in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_rehome_mod_paths(item, old_root, new_root, _seen) for item in obj]
+    if isinstance(obj, tuple):
+        rebuilt = tuple(
+            _rehome_mod_paths(item, old_root, new_root, _seen) for item in obj
+        )
+        if hasattr(obj, "_fields"):
+            return type(obj)(*rebuilt)
+        return rebuilt
+    if isinstance(obj, set):
+        return {_rehome_mod_paths(item, old_root, new_root, _seen) for item in obj}
+    if isinstance(obj, frozenset):
+        return frozenset(
+            _rehome_mod_paths(item, old_root, new_root, _seen) for item in obj
+        )
+    return obj
+
+
+def _pack(mod_path: str, result: Any) -> bytes:
+    return pickle.dumps(
+        (_CACHE_RECORD, mod_path, result), protocol=pickle.HIGHEST_PROTOCOL
+    )
+
+
+def _unpack(mod_path: str, blob: bytes) -> Any:
+    stored = pickle.loads(blob)
+    if not (
+        isinstance(stored, tuple) and len(stored) == 3 and stored[0] == _CACHE_RECORD
+    ):
+        raise pickle.UnpicklingError("not a v9 cache record")
+    old_root, payload = stored[1], stored[2]
+    if old_root == mod_path:
+        return payload
+    return _rehome_mod_paths(payload, old_root, mod_path)
 
 
 def _fingerprint_paths(namespace: str) -> list[Path]:
@@ -121,8 +230,9 @@ def _validator_code_fingerprint(namespace: str = "") -> str:
         return cached[1]
     digest = hashlib.sha256()
     for path in paths:
+        digest.update(_fingerprint_identity(path).encode("utf-8"))
+        digest.update(b"\0")
         try:
-            digest.update(str(path).encode("utf-8"))
             digest.update(path.read_bytes())
         except OSError:
             continue
@@ -210,7 +320,7 @@ def _get(mod_path: str, namespace: str, key: str, tag: str) -> Tuple[bool, Any]:
                 (namespace, key),
             ).fetchone()
         if row is not None and row[0] == tag:
-            return (True, pickle.loads(row[1]))
+            return (True, _unpack(mod_path, row[1]))
     except _DB_ERRORS:
         return (False, None)
     return (False, None)
@@ -222,7 +332,7 @@ def _put(mod_path: str, namespace: str, key: str, tag: str, result: Any) -> None
     if conn is None:
         return
     try:
-        blob = pickle.dumps(result, protocol=pickle.HIGHEST_PROTOCOL)
+        blob = _pack(mod_path, result)
         with _conns_lock:
             conn.execute(
                 "INSERT OR REPLACE INTO entries (namespace, key, tag, value)"
@@ -253,11 +363,12 @@ def per_file_cached(
     if current_stat is None:
         return compute_fn()
     tag = f"s:{_validator_code_fingerprint(namespace)}:{current_stat[0]}:{current_stat[1]}"
-    hit, result = _get(mod_path, namespace, source_path, tag)
+    key = _source_key(mod_path, source_path)
+    hit, result = _get(mod_path, namespace, key, tag)
     if hit:
         return result
     result = compute_fn()
-    _put(mod_path, namespace, source_path, tag, result)
+    _put(mod_path, namespace, key, tag, result)
     return result
 
 
@@ -280,19 +391,25 @@ def per_file_cached_by_content(
     if _cache_disabled():
         return compute_fn()
     tag = f"c:{_validator_code_fingerprint(namespace)}:{len(content)}:{hashlib.sha256(content.encode('utf-8')).hexdigest()}"
-    hit, result = _get(mod_path, namespace, source_path, tag)
+    key = _source_key(mod_path, source_path)
+    hit, result = _get(mod_path, namespace, key, tag)
     if hit:
         return result
     result = compute_fn()
-    _put(mod_path, namespace, source_path, tag, result)
+    _put(mod_path, namespace, key, tag, result)
     return result
 
 
-def _stats_tag(stats: Dict[str, Optional[Tuple[int, int]]], namespace: str = "") -> str:
+def _stats_tag(
+    stats: Dict[str, Optional[Tuple[int, int]]],
+    namespace: str = "",
+    mod_path: str = "",
+) -> str:
     parts = []
     for p in sorted(stats):
         v = stats[p]
-        parts.append(f"{p}={v[0]}:{v[1]}" if v else f"{p}=x")
+        name = _source_key(mod_path, p) if mod_path else p
+        parts.append(f"{name}={v[0]}:{v[1]}" if v else f"{name}=x")
     return (
         "a:"
         + _validator_code_fingerprint(namespace)
@@ -313,7 +430,7 @@ def aggregate_cached(
         return factory_fn()
     tracked: List[str] = list(tracked_files)
     current_stats = {p: _file_stat(p) for p in tracked}
-    tag = _stats_tag(current_stats, namespace)
+    tag = _stats_tag(current_stats, namespace, mod_path)
     hit, result = _get(mod_path, "__aggregate__", key, tag)
     if hit:
         return result

--- a/tools/validation/sprite_index.py
+++ b/tools/validation/sprite_index.py
@@ -132,12 +132,13 @@ def _textures_in_file(args) -> List[List[str]]:
             if not texture:
                 continue
             rel = texture.replace("\\", "/").lstrip("/")
-            pairs.append([name, os.path.normpath(os.path.join(root, rel))])
+            pairs.append([name, rel])
         return pairs
 
-    return disk_cache.per_file_cached_by_content(
+    cached = disk_cache.per_file_cached_by_content(
         mod_path, "sprite_index.textures", filepath, raw, _compute
     )
+    return [[name, os.path.normpath(os.path.join(root, rel))] for name, rel in cached]
 
 
 def build_sprite_texture_index(


### PR DESCRIPTION
## Bottom line

Copied `.validation_cache` databases now hit at another checkout of the same tree. Row keys are checkout-relative, code fingerprints ignore absolute tool paths, and stored payloads rehome embedded checkout paths. Sprite texture rows store `texturefile` relative paths and join them to the current `.gfx` root after a hit, so they cannot point at another tree or vanilla install.

## Why

#3925 asked for safe reuse across checkouts after #3917's helper invalidation. A copied cache previously missed every row because keys, fingerprints, and sprite payloads used absolute paths.

## How

`CACHE_VERSION` 9. No legacy cache migration. Vanilla install paths stay absolute. `MD_NO_CACHE` / `--no-cache` is unchanged. Measurement: a warm content cache copied to a second root does not recompute; changed content, helper edits, and deleted aggregate inputs still miss.

Closes #3925

BLUF