### PR TITLE
Fix USA collapse breakaways not spawning

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -20,6 +20,7 @@ Bugfix:
  - [UKR] All scientists recruited at game start, fixed incorrect scientist name references, and added 3 new scientists with portraits
  - [CHI] Fixed the Doklam wargoal issue (Issue #4029)
  - Fixed Heavy Frigate Module adding 2000 ORG to frigates
+ - [USA] Fixed the Free States of America not properly appearing due to a behavior change in change_tag_from form
 
 Database:
  - Portugal Bravia MIO changed from Generic Armor to Generic AFV

--- a/events/United States.txt
+++ b/events/United States.txt
@@ -12135,7 +12135,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.6.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.6.o2 executed"
-		TEX = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = texan_soldier }
 			set_nationality = TEX
@@ -12170,6 +12169,7 @@ country_event = {
 		}
 		hidden_effect = {
 			TEX = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 			}
@@ -12253,7 +12253,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.7.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.7.o2 executed"
-		CAS = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = cascadian_soldier }
 			set_nationality = CAS
@@ -12289,6 +12288,7 @@ country_event = {
 		}
 		hidden_effect = {
 			CAS = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 				country_event = { id = USA_collapse_event.30 days = 2 }
@@ -12363,7 +12363,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.8.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.8.o2 executed"
-		PTR = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = puerto_rican_soldier }
 			set_nationality = PTR
@@ -12390,6 +12389,7 @@ country_event = {
 		}
 		hidden_effect = {
 			PTR = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 			}
@@ -12477,7 +12477,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.9.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.9.o2 executed"
-		CSA = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = southern_soldier }
 			set_nationality = CSA
@@ -12512,6 +12511,7 @@ country_event = {
 		}
 		hidden_effect = {
 			CSA = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 				country_event = { id = USA_collapse_event.23 days = 2 }
@@ -12661,7 +12661,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.10.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.10.o2 executed"
-		CAL = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = california_soldier }
 			set_nationality = CAL
@@ -12692,6 +12691,7 @@ country_event = {
 		}
 		hidden_effect = {
 			CAL = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 			}
@@ -12772,7 +12772,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.11.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.11.o2 executed"
-		NEN = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = new_england_soldier }
 			set_nationality = NEN
@@ -12807,6 +12806,7 @@ country_event = {
 		}
 		hidden_effect = {
 			NEN = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 			}
@@ -12918,7 +12918,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.12.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.12.o2 executed"
-		NYK = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = new_yorker_soldier }
 			set_nationality = NYK
@@ -12949,6 +12948,7 @@ country_event = {
 		}
 		hidden_effect = {
 			NYK = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 			}
@@ -13029,7 +13029,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.13.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.13.o2 executed"
-		GLC = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = midwest_soldier }
 			set_nationality = GLC
@@ -13064,6 +13063,7 @@ country_event = {
 		}
 		hidden_effect = {
 			GLC = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 			}
@@ -13219,7 +13219,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.14.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.14.o2 executed"
-		LKT = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = great_plains_soldier }
 			set_nationality = LKT
@@ -13254,6 +13253,7 @@ country_event = {
 		}
 		hidden_effect = {
 			LKT = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 				country_event = { id = LKT_collapse_event.1 days = 3 }
@@ -13304,7 +13304,7 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-		tag = USA
+		original_tag = USA
 		has_full_control_of_state = 803
 		has_full_control_of_state = 804
 		has_full_control_of_state = 805
@@ -13373,7 +13373,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.15.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.15.o2 executed"
-		UDT = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = rocky_mountain_soldier }
 			set_nationality = UDT
@@ -13404,6 +13403,7 @@ country_event = {
 		}
 		hidden_effect = {
 			UDT = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 			}
@@ -13420,7 +13420,7 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-		tag = USA
+		original_tag = USA
 		has_full_control_of_state = 814
 		has_full_control_of_state = 1010
 	}
@@ -13480,7 +13480,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.16.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.16.o2 executed"
-		ASK = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = alaskan_soldier }
 			set_nationality = ASK
@@ -13511,6 +13510,7 @@ country_event = {
 		}
 		hidden_effect = {
 			ASK = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 			}
@@ -13527,7 +13527,7 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-		tag = USA
+		original_tag = USA
 		has_full_control_of_state = 817
 		has_full_control_of_state = 822
 		has_full_control_of_state = 823
@@ -13596,7 +13596,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.17.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.17.o2 executed"
-		HWI = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = pacific_islander_soldier }
 			set_nationality = HWI
@@ -13627,6 +13626,7 @@ country_event = {
 		}
 		hidden_effect = {
 			HWI = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 			}
@@ -13643,7 +13643,7 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-		tag = USA
+		original_tag = USA
 		has_full_control_of_state = 774
 		has_full_control_of_state = 773
 		has_full_control_of_state = 1083
@@ -13718,7 +13718,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = { tag = USB }
+	trigger = { original_tag = USB }
 
 	option = {
 		name = USA_collapse_event.19.o1
@@ -13825,7 +13825,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = { tag = USA }
+	trigger = { original_tag = USA }
 
 	option = {
 		name = USA_collapse_event.20.o1
@@ -13850,7 +13850,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = { tag = USA }
+	trigger = { original_tag = USA }
 
 	option = {
 		name = USA_collapse_event.21.o1
@@ -16318,9 +16318,6 @@ country_event = {
 	option = { # Violence
 		name = USA_crisis_event.1110.o2
 		log = "[GetDateText]: [This.GetName]: USA_crisis_event.1110.o2 executed"
-		TEX = {
-			change_tag_from = USA
-		}
 		country_event = {
 			id = USA_crisis_event.1111
 			days = 30
@@ -16358,6 +16355,7 @@ country_event = {
 		add_to_variable = { us_army_army_defence = -0.03 tooltip = army_defence_factor_tt }
 		hidden_effect = {
 			TEX = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 				country_event = { id = USA_crisis_event.1120 days = 4 }
@@ -16443,11 +16441,9 @@ country_event = {
 		TEX = {
 			country_event = { id = USA_crisis_event.1115 days = 7 }
 		}
-		CSA = {
-			change_tag_from = TEX
-		}
 		hidden_effect = {
 			CSA = {
+				change_tag_from = TEX
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 				country_event = { id = USA_crisis_event.1121 days = 3 }
@@ -16624,7 +16620,6 @@ country_event = {
 	option = { # War Escalation
 		name = USA_crisis_event.1115.o1
 		log = "[GetDateText]: [This.GetName]: USA_crisis_event.1115.o1 executed"
-		LKT = { change_tag_from = TEX }
 		USA = {
 			country_event = {
 				id = USA_crisis_event.1116
@@ -16636,6 +16631,7 @@ country_event = {
 		}
 		hidden_effect = {
 			LKT = {
+				change_tag_from = TEX
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 			}
@@ -16760,7 +16756,7 @@ country_event = {
 		name = USA_crisis_event.1117.o1
 		log = "[GetDateText]: [This.GetName]: USA_crisis_event.1117.o1 executed"
 		NEN = {
-			country_event = USA_crisis_event.1123
+			country_event = { id = USA_crisis_event.1123 days = 2 }
 			change_tag_from = TEX
 		}
 		USA = {
@@ -16889,7 +16885,6 @@ country_event = {
 	option = { # War Escalation
 		name = USA_crisis_event.1119.o1
 		log = "[GetDateText]: [This.GetName]: USA_crisis_event.1119.o1 executed"
-		PTR = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = puerto_rican_soldier }
 			set_nationality = PTR
@@ -16916,6 +16911,7 @@ country_event = {
 		}
 		hidden_effect = {
 			PTR = {
+				change_tag_from = USA
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
 			}


### PR DESCRIPTION
## Bottom line

Fixes USA collapse breakaway tags (including USB Free States) not spawning. Moves change_tag_from into the hidden_effect tag blocks so the tag switch runs with startup setup, switches collapse follow-up triggers from tag to original_tag so later breakaways still fire after the first tag switch, and fixes the NEN crisis event firing syntax.

Closes #4105

BLUF