### PR TITLE
Fix Kursk disaster ruling party support loss

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -21,6 +21,7 @@ Bugfix:
  - [CHI] Fixed the Doklam wargoal issue (Issue #4029)
  - Fixed Heavy Frigate Module adding 2000 ORG to frigates
  - [USA] Fixed the Free States of America not properly appearing due to a behavior change in change_tag_from form
+ - [RUS] Fixed the Kursk submarine disaster support loss targeting United Russia instead of the current ruling party (Issue #4035)
 
 Database:
  - Portugal Bravia MIO changed from Generic Armor to Generic AFV

--- a/events/Russia.txt
+++ b/events/Russia.txt
@@ -101,7 +101,7 @@ country_event = {
 		navy_experience = 2
 		add_stability = -0.02
 		add_political_power = -10
-		set_temp_variable = { party_index = 6 }
+
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes


### PR DESCRIPTION
### Changes

Fixes the Kursk submarine disaster event so the 5% party support loss applies to the current ruling party instead of always targeting United Russia.

The event previously hard-coded `party_index = 6`, which forced the popularity loss onto United Russia regardless of which party was governing Russia.

By removing the hard-coded party index, `change_relative_party_popularity` now uses its built-in fallback to detect the current ruling party.

Closes #4035